### PR TITLE
Add the bitbang-metrics-dump command and a build/test CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: bitbang-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: bitbang-server/go.mod
+          cache-dependency-path: bitbang-server/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./...
+
+      - name: Deploy cross-builds (linux/amd64, CGO_ENABLED=0)
+        # These mirror deploy/upload_production exactly. If either command
+        # directory goes missing, this step fails the build.
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /tmp/signaling-go ./cmd/signaling
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /tmp/bitbang-metrics-dump ./cmd/bitbang-metrics-dump

--- a/README.md
+++ b/README.md
@@ -139,12 +139,17 @@ Rolling back means redeploying a previous commit -- there's no built-in versione
 
 Set `METRICS_PATH` to also persist snapshots to SQLite on a timer. Counters survive restarts: on startup the server loads the most recent row, seeds its in-memory atomics, and writes a fresh row immediately so time-series queries don't show a phantom gap. At most one interval of un-flushed events is lost in a hard crash. Schema and PRAGMAs (WAL, `synchronous=NORMAL`) are applied on first open -- no setup. Budget roughly **30 MB/year** at the 5-minute default.
 
-Read it back with the bundled tool (no `sqlite3` package required):
+Read it back with the bundled tool (no `sqlite3` package required). The
+deploy ships the binary to `/opt/bitbang` and sets `METRICS_PATH` only in
+the service unit, so on the server point it at the database explicitly:
 
 ```bash
-bitbang-metrics-dump | jq .                # latest snapshot
-bitbang-metrics-dump -history 100 | jq .   # last 100 rows
+/opt/bitbang/bitbang-metrics-dump -db /opt/bitbang/metrics.db | jq .              # latest snapshot
+/opt/bitbang/bitbang-metrics-dump -db /opt/bitbang/metrics.db -history 100 | jq . # last 100 rows
 ```
+
+`-db` defaults to `$METRICS_PATH`, so if that variable is exported in your
+shell you can drop the flag.
 
 A bad `METRICS_PATH` is a **hard startup failure** -- better to refuse to boot than to silently discard metrics.
 

--- a/bitbang-server/.gitignore
+++ b/bitbang-server/.gitignore
@@ -6,9 +6,11 @@ deploy/production.deploy
 deploy/test.env
 deploy/test.deploy
 
-# Build artifacts (produced by upload_production / local builds):
-signaling-go
-bitbang-metrics-dump
+# Build artifacts from upload_production / local builds. Leading slash
+# anchors these to the module root so cmd/bitbang-metrics-dump/ is not
+# ignored too.
+/signaling-go
+/bitbang-metrics-dump
 *.tgz
 
 # Local SQLite metrics, if running the server locally for testing:

--- a/bitbang-server/cmd/bitbang-metrics-dump/main.go
+++ b/bitbang-server/cmd/bitbang-metrics-dump/main.go
@@ -1,0 +1,175 @@
+// Command bitbang-metrics-dump reads the metrics SQLite database written
+// by the signaling server's recorder (internal/metrics) and prints
+// snapshot rows as JSON.
+//
+// Usage:
+//
+//	bitbang-metrics-dump -db PATH              # latest snapshot, as a JSON object
+//	bitbang-metrics-dump -db PATH -history 100 # last 100 snapshots, as a JSON array
+//
+// -db defaults to $METRICS_PATH. The deploy ships this binary to
+// /opt/bitbang and sets METRICS_PATH only in the systemd unit, not in an
+// interactive shell, so on the server the invocation is explicit:
+//
+//	/opt/bitbang/bitbang-metrics-dump -db /opt/bitbang/metrics.db | jq .
+//
+// Rows are ordered newest-first. The counter keys are the wire-stable
+// names /status emits, because the row type embeds metrics.Snapshot.
+//
+// The tool is read-only: it opens the database with a mode=ro URI and
+// PRAGMA query_only, so it never creates the database and never modifies a
+// recorded row. It is safe to run against a live server's database.
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"bitbang-server-go/internal/metrics"
+
+	_ "modernc.org/sqlite" // pure-Go SQLite driver, registers as "sqlite"
+)
+
+// row is one snapshot row. The counter fields come from the embedded
+// metrics.Snapshot, so their JSON tags stay in step with /status. ts and
+// the two gauges are the extra columns the recorder writes; see the schema
+// in internal/metrics/recorder.go.
+type row struct {
+	TS      string `json:"ts"`
+	Devices int64  `json:"devices"`
+	Clients int64  `json:"clients"`
+	metrics.Snapshot
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return // flag already printed usage to stderr
+		}
+		fmt.Fprintln(os.Stderr, "bitbang-metrics-dump:", err)
+		os.Exit(1)
+	}
+}
+
+// run takes its args and output streams explicitly instead of reading
+// os.Args / os.Stdout, so the command can be driven from tests.
+func run(args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("bitbang-metrics-dump", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	dbPath := fs.String("db", os.Getenv("METRICS_PATH"),
+		"path to the metrics SQLite database (default $METRICS_PATH)")
+	history := fs.Int("history", 0,
+		"print the last N snapshots as a JSON array; 0 prints just the latest, as an object")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if *dbPath == "" {
+		return fmt.Errorf("no database path: pass -db or set METRICS_PATH")
+	}
+	if *history < 0 {
+		return fmt.Errorf("-history must be >= 0, got %d", *history)
+	}
+
+	db, err := openDB(*dbPath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+
+	if *history > 0 {
+		rows, err := queryRows(db, *history)
+		if err != nil {
+			return err
+		}
+		if rows == nil {
+			rows = []row{} // encode [] rather than null for the array form
+		}
+		return enc.Encode(rows)
+	}
+
+	rows, err := queryRows(db, 1)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		// No snapshots recorded yet. Emit JSON null so a downstream
+		// `| jq .` still gets valid input, and note it on stderr.
+		fmt.Fprintf(stderr, "bitbang-metrics-dump: no snapshots in %s\n", *dbPath)
+		return enc.Encode(nil)
+	}
+	return enc.Encode(rows[0])
+}
+
+// openDB opens the metrics database read-only: mode=ro so the driver never
+// creates it (os.Stat first for a friendlier "not found"), plus PRAGMA
+// query_only to reject writes at the SQL layer.
+func openDB(path string) (*sql.DB, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	// Resolve to an absolute path so the file: URI has an empty authority
+	// (file:///path); a relative path would be parsed as a URI host.
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	db, err := sql.Open("sqlite", readonlyDSN(abs))
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec("PRAGMA query_only = true"); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("open %s: set query_only: %w", path, err)
+	}
+	return db, nil
+}
+
+// readonlyDSN builds a read-only SQLite file: URI (mode=ro). path must be
+// absolute, so the URI has an empty authority (file:///path); url.URL
+// percent-encodes it so spaces or other reserved characters resolve to the
+// literal filename.
+func readonlyDSN(path string) string {
+	return (&url.URL{Scheme: "file", Path: filepath.ToSlash(path), RawQuery: "mode=ro"}).String()
+}
+
+// queryRows returns up to limit snapshot rows, newest first.
+func queryRows(db *sql.DB, limit int) ([]row, error) {
+	q, err := db.Query(`
+		SELECT ts, devices, clients, requests, direct, relay, tcp_relay, failed
+		FROM snapshots
+		ORDER BY ts DESC
+		LIMIT ?
+	`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("query snapshots: %w", err)
+	}
+	defer q.Close()
+
+	var out []row
+	for q.Next() {
+		var r row
+		if err := q.Scan(
+			&r.TS, &r.Devices, &r.Clients,
+			&r.Requests, &r.Direct, &r.Relay, &r.TCPRelay, &r.Failed,
+		); err != nil {
+			return nil, fmt.Errorf("scan row: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := q.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rows: %w", err)
+	}
+	return out, nil
+}

--- a/bitbang-server/cmd/bitbang-metrics-dump/main_test.go
+++ b/bitbang-server/cmd/bitbang-metrics-dump/main_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"bitbang-server-go/internal/metrics"
+)
+
+// countStub is a fixed metrics.Counter, enough to construct a Recorder so
+// the test builds the snapshots table with the real production schema.
+type countStub int
+
+func (c countStub) Count() int { return int(c) }
+
+// newSchemaDB creates a metrics database using the real recorder, so the
+// snapshots table matches exactly what the server writes. Tests using it
+// fail if the schema drifts.
+func newSchemaDB(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "metrics.db")
+	rec, err := metrics.NewRecorder(
+		metrics.New(), countStub(0), countStub(0),
+		dbPath, time.Minute,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+	if rec == nil {
+		t.Fatal("NewRecorder returned nil for a non-empty path")
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder Close: %v", err)
+	}
+	return dbPath
+}
+
+// insertRow writes one snapshot row directly, so the test controls the
+// timestamps (and therefore the ordering) deterministically.
+func insertRow(t *testing.T, path, ts string, devices, clients, requests int64) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open for insert: %v", err)
+	}
+	defer db.Close()
+	_, err = db.Exec(`
+		INSERT INTO snapshots (ts, devices, clients, requests, direct, relay, tcp_relay, failed)
+		VALUES (?, ?, ?, ?, 0, 0, 0, 0)
+	`, ts, devices, clients, requests)
+	if err != nil {
+		t.Fatalf("insert row: %v", err)
+	}
+}
+
+func seededDB(t *testing.T) string {
+	path := newSchemaDB(t)
+	insertRow(t, path, "2026-07-31T00:00:00Z", 1, 1, 100)
+	insertRow(t, path, "2026-07-31T00:05:00Z", 2, 2, 200)
+	insertRow(t, path, "2026-07-31T00:10:00Z", 3, 3, 300)
+	return path
+}
+
+func TestQueryRows_NewestFirst(t *testing.T) {
+	db, err := openDB(seededDB(t))
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer db.Close()
+
+	got, err := queryRows(db, 1)
+	if err != nil {
+		t.Fatalf("queryRows(1): %v", err)
+	}
+	if len(got) != 1 || got[0].TS != "2026-07-31T00:10:00Z" || got[0].Requests != 300 {
+		t.Fatalf("latest row = %+v, want the 00:10 / requests=300 row", got)
+	}
+
+	all, err := queryRows(db, 100)
+	if err != nil {
+		t.Fatalf("queryRows(100): %v", err)
+	}
+	wantTS := []string{"2026-07-31T00:10:00Z", "2026-07-31T00:05:00Z", "2026-07-31T00:00:00Z"}
+	if len(all) != len(wantTS) {
+		t.Fatalf("queryRows(100): want %d rows, got %d", len(wantTS), len(all))
+	}
+	for i, w := range wantTS {
+		if all[i].TS != w {
+			t.Errorf("row %d ts = %q, want %q (expected newest-first)", i, all[i].TS, w)
+		}
+	}
+}
+
+func TestQueryRows_EmptyDB(t *testing.T) {
+	db, err := openDB(newSchemaDB(t))
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer db.Close()
+
+	got, err := queryRows(db, 10)
+	if err != nil {
+		t.Fatalf("queryRows on empty DB: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("empty DB: want 0 rows, got %d", len(got))
+	}
+}
+
+func TestOpenDB_MissingFileErrorsAndDoesNotCreate(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist.db")
+	if _, err := openDB(missing); err == nil {
+		t.Fatal("openDB on a missing file should error")
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatalf("openDB created %s; it must be read-only and side-effect-free (stat err: %v)", missing, err)
+	}
+}
+
+// TestOpenDB_RejectsWrites proves the read-only guarantee that matters:
+// the connection cannot modify recorded metrics. mode=ro blocks writes at
+// the VFS layer and query_only blocks them at the SQL layer; either way,
+// data-modifying statements fail and the rows are left intact.
+func TestOpenDB_RejectsWrites(t *testing.T) {
+	db, err := openDB(seededDB(t))
+	if err != nil {
+		t.Fatalf("openDB: %v", err)
+	}
+	defer db.Close()
+
+	for _, stmt := range []string{
+		`INSERT INTO snapshots (ts,devices,clients,requests,direct,relay,tcp_relay,failed)
+			VALUES ('2026-07-31T09:99:99Z',0,0,0,0,0,0,0)`,
+		`UPDATE snapshots SET requests = 0`,
+		`DELETE FROM snapshots`,
+	} {
+		if _, err := db.Exec(stmt); err == nil {
+			t.Errorf("write succeeded but must be rejected: %s", stmt)
+		}
+	}
+
+	rows, err := queryRows(db, 100)
+	if err != nil {
+		t.Fatalf("queryRows: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("rows after rejected writes = %d, want 3 unchanged", len(rows))
+	}
+}
+
+// TestOpenDB_SpecialCharPath exercises readonlyDSN: a database whose path
+// contains characters that must be percent-encoded in a file: URI (a space
+// and a %) still has to open and read back. The writer uses the raw path
+// and the reader goes through readonlyDSN, so they must resolve to the same
+// file.
+func TestOpenDB_SpecialCharPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "od d 50%")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(dir, "metrics.db")
+
+	rec, err := metrics.NewRecorder(
+		metrics.New(), countStub(0), countStub(0),
+		path, time.Minute,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if err != nil {
+		t.Fatalf("NewRecorder: %v", err)
+	}
+	if err := rec.Close(); err != nil {
+		t.Fatalf("recorder Close: %v", err)
+	}
+	insertRow(t, path, "2026-07-31T00:00:00Z", 1, 2, 42)
+
+	db, err := openDB(path)
+	if err != nil {
+		t.Fatalf("openDB on a path with a space and %%: %v", err)
+	}
+	defer db.Close()
+
+	got, err := queryRows(db, 1)
+	if err != nil {
+		t.Fatalf("queryRows: %v", err)
+	}
+	if len(got) != 1 || got[0].Requests != 42 {
+		t.Fatalf("read back = %+v, want requests=42", got)
+	}
+}
+
+// TestOpenDB_RelativePath guards against the file: URI treating a relative
+// path as an authority (file://name). openDB must resolve it to an absolute
+// path first. This is how the tool is used with `-db metrics.db` or
+// METRICS_PATH=metrics.db.
+func TestOpenDB_RelativePath(t *testing.T) {
+	path := seededDB(t)
+	t.Chdir(filepath.Dir(path))
+
+	db, err := openDB(filepath.Base(path))
+	if err != nil {
+		t.Fatalf("openDB(relative): %v", err)
+	}
+	defer db.Close()
+
+	got, err := queryRows(db, 1)
+	if err != nil {
+		t.Fatalf("queryRows: %v", err)
+	}
+	if len(got) != 1 || got[0].Requests != 300 {
+		t.Fatalf("relative-path read = %+v, want requests=300", got)
+	}
+}
+
+func TestRun_LatestObject(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := run([]string{"-db", seededDB(t)}, &out, &errb); err != nil {
+		t.Fatalf("run: %v (stderr: %s)", err, errb.String())
+	}
+	var got row
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not a JSON object: %v\n%s", err, out.String())
+	}
+	if got.TS != "2026-07-31T00:10:00Z" || got.Requests != 300 {
+		t.Fatalf("latest object = %+v, want the 00:10 / requests=300 row", got)
+	}
+}
+
+func TestRun_HistoryArray(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := run([]string{"-db", seededDB(t), "-history", "5"}, &out, &errb); err != nil {
+		t.Fatalf("run: %v (stderr: %s)", err, errb.String())
+	}
+	var got []row
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not a JSON array: %v\n%s", err, out.String())
+	}
+	if len(got) != 3 || got[0].TS != "2026-07-31T00:10:00Z" {
+		t.Fatalf("history array = %+v, want 3 rows newest-first", got)
+	}
+}
+
+func TestRun_EmptyDB_EmitsNull(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := run([]string{"-db", newSchemaDB(t)}, &out, &errb); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "null" {
+		t.Fatalf("empty DB stdout = %q, want null", out.String())
+	}
+	if !strings.Contains(errb.String(), "no snapshots") {
+		t.Fatalf("empty DB stderr = %q, want a 'no snapshots' note", errb.String())
+	}
+}
+
+func TestRun_EmptyHistory_EmitsArray(t *testing.T) {
+	var out, errb bytes.Buffer
+	if err := run([]string{"-db", newSchemaDB(t), "-history", "5"}, &out, &errb); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if strings.TrimSpace(out.String()) != "[]" {
+		t.Fatalf("empty history stdout = %q, want []", out.String())
+	}
+}
+
+func TestRun_EnvFallback(t *testing.T) {
+	t.Setenv("METRICS_PATH", seededDB(t))
+	var out, errb bytes.Buffer
+	if err := run(nil, &out, &errb); err != nil {
+		t.Fatalf("run with $METRICS_PATH: %v (stderr: %s)", err, errb.String())
+	}
+	var got row
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not a JSON object: %v\n%s", err, out.String())
+	}
+	if got.Requests != 300 {
+		t.Fatalf("env-fallback latest = %+v, want requests=300", got)
+	}
+}
+
+func TestRun_NoPath_Errors(t *testing.T) {
+	t.Setenv("METRICS_PATH", "")
+	var out, errb bytes.Buffer
+	err := run(nil, &out, &errb)
+	if err == nil || !strings.Contains(err.Error(), "no database path") {
+		t.Fatalf("run with no path: err = %v, want a 'no database path' error", err)
+	}
+}
+
+func TestRun_NegativeHistory_Errors(t *testing.T) {
+	var out, errb bytes.Buffer
+	err := run([]string{"-db", seededDB(t), "-history", "-1"}, &out, &errb)
+	if err == nil || !strings.Contains(err.Error(), ">= 0") {
+		t.Fatalf("negative history: err = %v, want a '>= 0' error", err)
+	}
+}
+
+// TestRowJSONKeys pins the output contract: the counter keys inherited from
+// the embedded metrics.Snapshot, plus ts and the two gauges. These counter
+// keys are the ones /status also emits; the full /status object carries more
+// (version, protocol, active_codes), so this is a subset, not the same set.
+func TestRowJSONKeys(t *testing.T) {
+	r := row{TS: "2026-07-31T00:00:00Z", Devices: 4, Clients: 7}
+	r.Requests = 11
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := string(b)
+	for _, key := range []string{
+		`"ts"`, `"devices"`, `"clients"`,
+		`"connection_requests_total"`,
+		`"connections_direct_total"`,
+		`"connections_relay_total"`,
+		`"connections_tcp_relay_total"`,
+		`"connections_failed_total"`,
+	} {
+		if !strings.Contains(out, key) {
+			t.Errorf("row JSON missing key %s; got %s", key, out)
+		}
+	}
+}

--- a/bitbang-server/deploy/production.env.example
+++ b/bitbang-server/deploy/production.env.example
@@ -34,9 +34,11 @@ TURN_MAX_ACTIVE=0
 # WAL auto-checkpoints; no VACUUM scheduling needed for normal operation.
 #
 # Inspect from the shell with either `sqlite3 /opt/bitbang/metrics.db`
-# (requires apt install sqlite3) or the bundled bitbang-metrics-dump
-# tool: `bitbang-metrics-dump | jq .` for the latest row, or
-# `bitbang-metrics-dump -history 100 | jq .` for the last 100 rows.
+# (requires apt install sqlite3) or the bundled bitbang-metrics-dump tool,
+# which ships to /opt/bitbang alongside signaling-go:
+#   /opt/bitbang/bitbang-metrics-dump -db /opt/bitbang/metrics.db | jq .
+#   /opt/bitbang/bitbang-metrics-dump -db /opt/bitbang/metrics.db -history 100 | jq .
+# (-db defaults to $METRICS_PATH when that's exported in your shell.)
 METRICS_PATH=/opt/bitbang/metrics.db
 METRICS_INTERVAL=300
 


### PR DESCRIPTION
## What & why

`deploy/upload_production` cross-compiles `./cmd/bitbang-metrics-dump` and ships it beside `signaling-go`, and the README + `production.env.example` document it. But the command source was never committed, so the documented production deploy fails at build time:

```
stat .../cmd/bitbang-metrics-dump: directory not found
```

Two things kept this hidden: the *test* deploy (`upload_test`) only builds `./cmd/signaling`, and there was no CI. The source was also swallowed by an unanchored `bitbang-metrics-dump` line in `.gitignore`, which matches the `cmd/bitbang-metrics-dump/` **directory** as well as the intended root binary, so it could not be committed in the first place.

## What's in this PR

**The command** the docs already describe:

- no args: the latest snapshot, as a JSON object
- `-history N`: the last N snapshots, as a JSON array, newest first
- `-db PATH`: the database (defaults to `$METRICS_PATH`)

It reads the same SQLite database the recorder writes (`internal/metrics`) via the pure-Go `modernc.org/sqlite` driver already in the module, so it builds under `CGO_ENABLED=0` like the deploy expects. No new dependencies. The `row` type embeds `metrics.Snapshot`, so the counter keys are the ones `/status` emits (`ts` and the two gauges are added on top; `/status` also carries `version`/`protocol`/`active_codes`, so this is a subset). It opens the database read-only (`mode=ro` plus `PRAGMA query_only`): it never creates the database and never modifies a recorded row.

**Deploy realism:** the binary ships to `/opt/bitbang` and `METRICS_PATH` is set only in the systemd unit, so a bare `bitbang-metrics-dump` on the box would hit "command not found" (or, with the full path, "no database path"). The README and `production.env.example` now show the explicit on-server invocation.

**Tests** run through the real recorder (so they fail if the schema drifts) and cover the command end to end: object vs. array vs. `null`/`[]` output, the `$METRICS_PATH` fallback, missing-path and negative-history errors, write rejection, special-character and relative database paths, and the JSON-key contract.

**`.gitignore`** anchors the two build-artifact patterns to the module root, so a source directory can no longer collide with an ignored binary.

**CI** (new): `go vet`, `go test`, and the two deploy cross-builds, so a missing build target fails in CI instead of at deploy time.

## Verification

```
$ CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /tmp/bitbang-metrics-dump ./cmd/bitbang-metrics-dump   # OK
$ go vet ./...     # clean
$ go test ./...    # pass (14 tests in the new package)
```

Example output:

```json
{
  "ts": "2026-07-31T00:05:00Z",
  "devices": 4,
  "clients": 6,
  "connection_requests_total": 200,
  "connections_direct_total": 120,
  "connections_relay_total": 60,
  "connections_tcp_relay_total": 10,
  "connections_failed_total": 10
}
```

One question: is `bitbang-metrics-dump` meant to exist (this PR assumes so, since the deploy and docs call for it), or was it dropped on purpose? If it was dropped, I can instead remove the references; the CI check stands either way.
