### PR TITLE
Add browser support for per-stream flow control

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # --check only parses, but that is the right budget for scripts that
+      # otherwise ship untested (bootstrap.js, sw.js, the shims): it catches
+      # the syntax error that would brick every session at page load.
+      - name: Syntax-check browser scripts
+        working-directory: bitbang-server
+        run: |
+          for f in web/*.js; do node --check "$f"; done
+
+      # An explicit glob rather than a bare directory: it pins exactly
+      # which files run instead of leaning on the runner's discovery rules.
+      - name: Run web tests
+        working-directory: bitbang-server
+        run: node --test web_test/*.test.js

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ cd bitbang-server
 go build ./...
 go test ./...     # ~16s; pairing and handler suites include real timing waits
 go vet ./...
+node --test web_test/*.test.js
 ```
 
 The handler and pairing suites exercise the 3-second lookup delay and full pair round-trips against a live `httptest` server, so they're slow by design.

--- a/bitbang-server/internal/handler/static.go
+++ b/bitbang-server/internal/handler/static.go
@@ -20,11 +20,13 @@ const frontPagePlaceholder = "<!-- FRONT_PAGE -->"
 // allowedBitbangAssets is the whitelist of files served at /__bitbang__/<file>.
 // Anything else returns 404. Matches signaling.py exactly.
 var allowedBitbangAssets = map[string]bool{
-	"sw.js":         true,
-	"bootstrap.js":  true,
-	"ws-shim.js":    true,
-	"xhr-shim.js":   true,
-	"favicon.ico":   true, // handler internally maps this to favicon.png
+	"sw.js":           true,
+	"sw-upload.js":    true,
+	"flow-control.js": true,
+	"bootstrap.js":    true,
+	"ws-shim.js":      true,
+	"xhr-shim.js":     true,
+	"favicon.ico":     true, // handler internally maps this to favicon.png
 }
 
 // Static returns an http.Handler that serves the signaling server's static

--- a/bitbang-server/web/bootstrap.html
+++ b/bitbang-server/web/bootstrap.html
@@ -89,6 +89,7 @@
     <div id="connection-ui">
         <div id="status">Loading...</div>
     </div>
+    <script src="/__bitbang__/flow-control.js"></script>
     <script src="/__bitbang__/bootstrap.js"></script>
 </body>
 </html>

--- a/bitbang-server/web/bootstrap.js
+++ b/bitbang-server/web/bootstrap.js
@@ -333,12 +333,6 @@ class BitBangConnection {
         this.flow.open(streamId);
     }
 
-    _advertiseStream(streamId) {
-        if (this.flow.advertise(streamId)) return;
-        this._resetStream(streamId, 'flow_control', 'failed to advertise receive window', true);
-        throw new Error('failed to advertise receive window');
-    }
-
     _sendStreamSYN(streamId, flags, payload) {
         this._openStream(streamId);
         try {
@@ -347,9 +341,6 @@ class BitBangConnection {
             this.flow.resetStream(streamId, e);
             throw e;
         }
-        // Both directions become live with the first SYN. Several stream
-        // types send response DAT without a separate response SYN.
-        this._advertiseStream(streamId);
     }
 
     _applicationBytes(frame) {

--- a/bitbang-server/web/bootstrap.js
+++ b/bitbang-server/web/bootstrap.js
@@ -77,6 +77,8 @@ const FLAG_FIN = 0x0004;
 const FLAG_DAT = 0x0000;
 const FLAG_MORE = 0x0002;  // non-final fragment of a chunked WS message
 const SWSP_CHUNK_SIZE = 16384;  // max payload bytes per data-channel frame
+const SWSP_VERSION = SWSPFlowControl.VERSION;
+const SWSP_BUFFER_LIMIT = 1024 * 1024;
 
 // Soft reconnect: when an established peer connection drops (e.g. a transient
 // network blip on a long-lived session), rebuild the transport under the live
@@ -264,6 +266,10 @@ class BitBangConnection {
         this.connectResolve = null;   // resolved when device sends 'ready'
         this.nextStreamId = 1;        // streamId 0 is reserved for control
         this.wsStreams = new Map();    // streamId -> { iframe } for WebSocket bridging
+        this.negotiatedVersion = 2;
+        this._protocolReady = false;
+        this.sendChains = new Map();
+        this.flow = new SWSPFlowControl.Controller((msg) => this._sendControl(msg));
         this.sessionId = Array.from(crypto.getRandomValues(new Uint8Array(4)), b => b.toString(16).padStart(2, '0')).join(''); // 8 hex chars
         console.log('[Bootstrap] ctor', this.sessionId);
         this.candidateQueue = new CandidateQueue();
@@ -295,32 +301,193 @@ class BitBangConnection {
 
     // SWSP frame helpers
     createFrame(streamId, flags, payload) {
-        // payload can be string or Uint8Array
-        let payloadBytes;
-        if (typeof payload === 'string') {
-            payloadBytes = new TextEncoder().encode(payload);
-        } else if (payload instanceof ArrayBuffer) {
-            payloadBytes = new Uint8Array(payload);
-        } else {
-            payloadBytes = payload;
-        }
-
-        const buffer = new ArrayBuffer(8 + payloadBytes.byteLength);
-        const view = new DataView(buffer);
-        view.setUint32(0, streamId, true);  // little-endian
-        view.setUint16(4, flags, true);
-        view.setUint16(6, payloadBytes.byteLength, true);
-        new Uint8Array(buffer).set(payloadBytes, 8);
-        return buffer;
+        return SWSPFlowControl.createFrame(streamId, flags, payload);
     }
 
     parseFrame(buffer) {
-        const view = new DataView(buffer);
-        const streamId = view.getUint32(0, true);
-        const flags = view.getUint16(4, true);
-        const length = view.getUint16(6, true);
-        const payload = buffer.slice(8, 8 + length);
-        return { streamId, flags, payload };
+        return SWSPFlowControl.parseFrame(buffer);
+    }
+
+    _sendControl(msg) {
+        if (!this.dataChannel || this.dataChannel.readyState !== 'open') return false;
+        try {
+            this.dataChannel.send(this.createFrame(0, FLAG_SYN, JSON.stringify(msg)));
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
+    _validStreamId(streamId) {
+        return Number.isSafeInteger(streamId) && streamId > 0 && streamId <= 0xffffffff;
+    }
+
+    _allocateStreamId() {
+        const streamId = this.nextStreamId++;
+        if (!this._validStreamId(streamId)) throw new Error('SWSP stream IDs exhausted');
+        return streamId;
+    }
+
+    _openStream(streamId) {
+        if (!this._validStreamId(streamId)) throw new Error('invalid SWSP stream ID');
+        this.flow.open(streamId);
+    }
+
+    _advertiseStream(streamId) {
+        if (this.flow.advertise(streamId)) return;
+        this._resetStream(streamId, 'flow_control', 'failed to advertise receive window', true);
+        throw new Error('failed to advertise receive window');
+    }
+
+    _sendStreamSYN(streamId, flags, payload) {
+        this._openStream(streamId);
+        try {
+            this.dataChannel.send(this.createFrame(streamId, flags, payload));
+        } catch (e) {
+            this.flow.resetStream(streamId, e);
+            throw e;
+        }
+        // Both directions become live with the first SYN. Several stream
+        // types send response DAT without a separate response SYN.
+        this._advertiseStream(streamId);
+    }
+
+    _applicationBytes(frame) {
+        if (frame.streamId === 0 || (frame.flags & FLAG_SYN)) return 0;
+        return frame.payload?.byteLength || 0;
+    }
+
+    _acceptFrame(frame) {
+        if (frame.flags & FLAG_SYN) {
+            if (!this.flow.has(frame.streamId)) {
+                this._resetStream(frame.streamId, 'protocol_error', 'unexpected inbound stream', true);
+                return false;
+            }
+            if ((frame.flags & FLAG_FIN) && !this.flow.finishReceive(frame.streamId)) {
+                this._resetStream(frame.streamId, 'protocol_error', 'frame received after FIN', true);
+                return false;
+            }
+            return true;
+        }
+        const bytes = this._applicationBytes(frame);
+        if (this.flow.receive(frame.streamId, bytes, !!(frame.flags & FLAG_FIN))) return true;
+        this._resetStream(frame.streamId, 'flow_control', 'receive window exceeded', true);
+        return false;
+    }
+
+    _consumeFrame(streamId, byteLength, frames) {
+        if (!this.flow.has(streamId)) return false;
+        if (this.flow.consume(streamId, byteLength, frames)) return true;
+        this._resetStream(streamId, 'protocol_error', 'invalid receive acknowledgement', true);
+        return false;
+    }
+
+    _registerWSAck(ws, byteLength, frames, onAck) {
+        if (!ws._receiveAcks) ws._receiveAcks = new Map();
+        let token;
+        do {
+            const words = crypto.getRandomValues(new Uint32Array(4));
+            token = Array.from(words, word => word.toString(16).padStart(8, '0')).join('');
+        } while (ws._receiveAcks.has(token));
+        ws._receiveAcks.set(token, { byteLength, frames, onAck });
+        return token;
+    }
+
+    _handleWSAck(streamId, token) {
+        const ws = this.wsStreams.get(streamId);
+        const ack = ws?._receiveAcks?.get(token);
+        if (!ws || !ack) {
+            if (ws) this._resetStream(streamId, 'protocol_error', 'invalid WebSocket acknowledgement', true);
+            return;
+        }
+        ws._receiveAcks.delete(token);
+        if (ack.frames > 0 && !this._consumeFrame(streamId, ack.byteLength, ack.frames)) return;
+        if (ack.onAck) ack.onAck();
+    }
+
+    _finishRequest(streamId) {
+        const req = this.pendingRequests.get(streamId);
+        if (!req || !req.localFinished || !req.responseClosed) return;
+        clearTimeout(req.timeout);
+        if (req.cleanupTimeout) clearTimeout(req.cleanupTimeout);
+        this.pendingRequests.delete(streamId);
+        this.flow.resetStream(streamId, new Error('stream complete'));
+    }
+
+    async _waitForDataChannel(streamId) {
+        while (this.dataChannel?.readyState === 'open'
+            && this.dataChannel.bufferedAmount > SWSP_BUFFER_LIMIT) {
+            if (!this.flow.has(streamId)) throw new Error('stream closed');
+            await new Promise(resolve => setTimeout(resolve, 10));
+        }
+        if (!this.dataChannel || this.dataChannel.readyState !== 'open') {
+            throw new Error('data channel closed');
+        }
+    }
+
+    _queueStreamFrame(streamId, flags, payload) {
+        const byteLength = (flags & FLAG_SYN) ? 0 : (payload?.byteLength || 0);
+        let wireFrame;
+        try {
+            wireFrame = this.createFrame(streamId, flags, payload);
+        } catch (e) {
+            return Promise.reject(e);
+        }
+        const previous = this.sendChains.get(streamId) || Promise.resolve();
+        const send = previous.catch(() => {}).then(async () => {
+            await this.flow.waitToSend(streamId, byteLength);
+            await this._waitForDataChannel(streamId);
+            if (!this.flow.has(streamId)) throw new Error('stream closed');
+            this.dataChannel.send(wireFrame);
+        });
+        this.sendChains.set(streamId, send);
+        const cleanup = () => {
+            if (this.sendChains.get(streamId) === send) this.sendChains.delete(streamId);
+        };
+        send.then(cleanup, cleanup);
+        return send;
+    }
+
+    _resetStream(streamId, code, message, notifyPeer) {
+        const error = new SWSPFlowControl.FlowError(code, message);
+        this.flow.resetStream(streamId, error);
+        this.sendChains.delete(streamId);
+
+        const req = this.pendingRequests.get(streamId);
+        if (req) {
+            clearTimeout(req.timeout);
+            if (req.cleanupTimeout) clearTimeout(req.cleanupTimeout);
+            this.pendingRequests.delete(streamId);
+            try { req.responsePort.postMessage({ type: 'error', message }); } catch (e) {}
+        }
+
+        const ws = this.wsStreams.get(streamId);
+        if (ws) {
+            ws._rxParts = null;
+            ws._pendingFrames = [];
+            ws._receiveAcks?.clear();
+            if (ws._closeTimeout) clearTimeout(ws._closeTimeout);
+            this.wsStreams.delete(streamId);
+            try {
+                ws.iframe.postMessage({ type: 'ws-error', streamId, message }, '*');
+                ws.iframe.postMessage({
+                    type: 'ws-closed', streamId, code: 1006, reason: message,
+                }, '*');
+            } catch (e) {}
+        }
+
+        if (notifyPeer && this.negotiatedVersion >= SWSP_VERSION) {
+            this._sendControl({
+                type: 'stream_reset', stream_id: streamId, code, message,
+            });
+        }
+
+        if (notifyPeer && this.negotiatedVersion < SWSP_VERSION
+            && this.dataChannel?.readyState === 'open') {
+            try {
+                this.dataChannel.send(this.createFrame(streamId, FLAG_FIN, new Uint8Array(0)));
+            } catch (e) {}
+        }
     }
 
     // Append one line to the connection log — a plain append-only terminal:
@@ -433,9 +600,10 @@ class BitBangConnection {
         const { method, url, headers, hasBody, contentLength } = data;
         if (this.debug) console.log(`[Bootstrap] Received proxy request: ${method} ${new URL(url).pathname}, DC state: ${this.dataChannel?.readyState}`);
 
-        if (!this.dataChannel || this.dataChannel.readyState !== 'open') {
+        if (!this.dataChannel || this.dataChannel.readyState !== 'open'
+            || !this.deviceVerified || !this._protocolReady) {
             console.warn('[Bootstrap] Data channel not open, rejecting request');
-            responsePort.postMessage({ type: 'error', message: 'Data channel not open' });
+            responsePort.postMessage({ type: 'error', message: 'Connection not ready' });
             // A live page with a dead channel should be recovering, not
             // rejecting forever — kick the reconnect if nothing else did.
             // (No-op while a reconnect is in flight or after a terminal end.)
@@ -452,7 +620,7 @@ class BitBangConnection {
         const fullPath = pathname + parsed.search;
 
         // Use incrementing stream ID for SWSP
-        const streamId = this.nextStreamId++;
+        const streamId = this._allocateStreamId();
 
         // Initial 30s timeout to catch "device not responding". Cleared once
         // response headers arrive (SYN). After that we rely on FIN / data
@@ -462,20 +630,24 @@ class BitBangConnection {
         const resetTimeout = () => {
             clearTimeout(timeout);
             timeout = setTimeout(() => {
-                this.pendingRequests.delete(streamId);
-                responsePort.postMessage({ type: 'error', message: 'Request timeout' });
+                this._resetStream(streamId, 'timeout', 'Request timeout', true);
             }, 30000);
+            const req = this.pendingRequests.get(streamId);
+            if (req) req.timeout = timeout;
         };
         resetTimeout();
 
         this.pendingRequests.set(streamId, {
             responsePort,
             timeout,
-            resetTimeout,
             bytesReceived: 0,
             startTime: Date.now(),
             nextLogMB: 50,
-            isUpload: hasBody
+            isUpload: hasBody,
+            localFinished: !hasBody,
+            remoteFinished: false,
+            responseClosed: false,
+            headersReceived: false,
         });
 
         // Build request metadata with all headers. SWSP v3 makes the
@@ -492,11 +664,10 @@ class BitBangConnection {
 
         if (hasBody) {
             // Send SYN frame with metadata, then stream body chunks as they arrive
-            const synFrame = this.createFrame(streamId, FLAG_SYN, JSON.stringify(requestMeta));
             try {
-                this.dataChannel.send(synFrame);
+                this._sendStreamSYN(streamId, FLAG_SYN, JSON.stringify(requestMeta));
             } catch (e) {
-                responsePort.postMessage({ type: 'error', message: 'Failed to start upload' });
+                this._resetStream(streamId, 'send_error', 'Failed to start upload', false);
                 this.progressChannel.postMessage({ type: 'uploadFailed' });
                 return;
             }
@@ -507,14 +678,30 @@ class BitBangConnection {
             let processingChain = Promise.resolve();
 
             const failUpload = (msg) => {
-                this.pendingRequests.delete(streamId);
-                responsePort.postMessage({ type: 'error', message: msg });
+                if (this.pendingRequests.has(streamId)) {
+                    this._resetStream(streamId, 'upload_error', msg, isOpen());
+                }
                 this.progressChannel.postMessage({ type: 'uploadFailed' });
             };
 
             const isOpen = () => this.dataChannel?.readyState === 'open';
 
             responsePort.onmessage = (event) => {
+                if (event.data.type === 'responseConsumed') {
+                    this._consumeFrame(streamId, event.data.bytes || 0, event.data.frames || 1);
+                    return;
+                }
+                if (event.data.type === 'responseClosed') {
+                    const req = this.pendingRequests.get(streamId);
+                    if (req?.cleanupTimeout) clearTimeout(req.cleanupTimeout);
+                    if (req) req.responseClosed = true;
+                    this._finishRequest(streamId);
+                    return;
+                }
+                if (event.data.type === 'cancel') {
+                    this._resetStream(streamId, 'cancelled', event.data.message || 'request cancelled', true);
+                    return;
+                }
                 processingChain = processingChain.then(async () => {
                     if (!isOpen()) return failUpload('Connection lost');
 
@@ -522,15 +709,18 @@ class BitBangConnection {
                         const data = event.data.data;
 
                         for (let i = 0; i < data.byteLength; i += MAX_CHUNK) {
-                            // Backpressure: wait while buffer is full
-                            while (isOpen() && this.dataChannel.bufferedAmount > 1024 * 1024) {
-                                await new Promise(r => setTimeout(r, 10));
-                            }
-                            if (!isOpen()) return failUpload('Connection lost');
-
                             const chunk = data.subarray(i, Math.min(i + MAX_CHUNK, data.byteLength));
-                            this.dataChannel.send(this.createFrame(streamId, FLAG_DAT, chunk));
+                            try {
+                                await this._queueStreamFrame(streamId, FLAG_DAT, chunk);
+                            } catch (e) {
+                                return failUpload(e.message || 'Connection lost');
+                            }
                         }
+
+                        // The service worker does not read the next request-body
+                        // chunk until this one has passed both stream credit and
+                        // the data-channel aggregate buffer.
+                        responsePort.postMessage({ type: 'bodyAck', seq: event.data.seq });
 
                         bytesSent += data.byteLength;
                         const now = Date.now();
@@ -545,14 +735,39 @@ class BitBangConnection {
                     } else if (event.data.type === 'bodyEnd') {
                         if (!isOpen()) return failUpload('Connection lost');
                         this.progressChannel.postMessage({ type: 'uploadComplete' });
-                        this.dataChannel.send(this.createFrame(streamId, FLAG_FIN, new Uint8Array(0)));
+                        try {
+                            await this._queueStreamFrame(streamId, FLAG_FIN, new Uint8Array(0));
+                            const req = this.pendingRequests.get(streamId);
+                            if (req) {
+                                req.localFinished = true;
+                                this._finishRequest(streamId);
+                            }
+                        } catch (e) {
+                            return failUpload(e.message || 'Connection lost');
+                        }
                     }
                 });
             };
         } else {
             // No body - send SYN|FIN together
-            const frame = this.createFrame(streamId, FLAG_SYN | FLAG_FIN, JSON.stringify(requestMeta));
-            this.dataChannel.send(frame);
+            try {
+                this._sendStreamSYN(streamId, FLAG_SYN | FLAG_FIN, JSON.stringify(requestMeta));
+            } catch (e) {
+                this._resetStream(streamId, 'send_error', 'Failed to start request', false);
+                return;
+            }
+            responsePort.onmessage = (event) => {
+                if (event.data.type === 'responseConsumed') {
+                    this._consumeFrame(streamId, event.data.bytes || 0, event.data.frames || 1);
+                } else if (event.data.type === 'responseClosed') {
+                    const req = this.pendingRequests.get(streamId);
+                    if (req?.cleanupTimeout) clearTimeout(req.cleanupTimeout);
+                    if (req) req.responseClosed = true;
+                    this._finishRequest(streamId);
+                } else if (event.data.type === 'cancel') {
+                    this._resetStream(streamId, 'cancelled', event.data.message || 'request cancelled', true);
+                }
+            };
         }
     }
 
@@ -1193,6 +1408,16 @@ class BitBangConnection {
         this.remoteDescriptionSet = false;
         this.deviceVerified = false;
         this.connectResolve = null;
+        for (const streamId of Array.from(this.pendingRequests.keys())) {
+            this._resetStream(streamId, 'session_closed', 'connection lost', false);
+        }
+        for (const streamId of Array.from(this.wsStreams.keys())) {
+            this._resetStream(streamId, 'session_closed', 'connection lost', false);
+        }
+        this.flow.reset(false);
+        this.sendChains.clear();
+        this.negotiatedVersion = 2;
+        this._protocolReady = false;
         this.candidateQueue = new CandidateQueue();
         this._wasConnected = false;
         this._usingRelay = false;
@@ -1236,9 +1461,22 @@ class BitBangConnection {
 
             // StreamId 0 is reserved for control messages (connect/ready/auth)
             if (frame.streamId === 0) {
-                this.handleControlMessage(frame);
+                this.handleControlMessage(frame).catch((error) => {
+                    const text = new TextDecoder().decode(frame.payload);
+                    const type = /"type"\s*:\s*"(window_update|stream_reset)"/.exec(text)?.[1];
+                    const rawId = /"stream_id"\s*:\s*(\d+)/.exec(text)?.[1];
+                    const streamId = rawId === undefined ? NaN : Number(rawId);
+                    if (type && this._validStreamId(streamId) && this.flow.has(streamId)) {
+                        this._resetStream(
+                            streamId, 'protocol_error', 'malformed stream control', true);
+                    } else {
+                        console.error('Error parsing SWSP control frame:', error);
+                    }
+                });
                 return;
             }
+
+            if (!this._acceptFrame(frame)) return;
 
             // WebSocket stream -- forward to iframe
             const ws = this.wsStreams.get(frame.streamId);
@@ -1255,9 +1493,26 @@ class BitBangConnection {
             }
 
             if (frame.flags & FLAG_SYN) {
+                if (req.headersReceived) {
+                    this._resetStream(frame.streamId, 'protocol_error', 'duplicate response SYN', true);
+                    return;
+                }
+                req.headersReceived = true;
                 // Metadata frame - send headers to SW, it will create the stream
                 const text = new TextDecoder().decode(frame.payload);
-                const metadata = JSON.parse(text);
+                let metadata;
+                try {
+                    metadata = JSON.parse(text);
+                } catch (e) {
+                    this._resetStream(
+                        frame.streamId, 'protocol_error', 'invalid HTTP response metadata', true);
+                    return;
+                }
+                if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+                    this._resetStream(
+                        frame.streamId, 'protocol_error', 'invalid HTTP response metadata', true);
+                    return;
+                }
                 const status = metadata.status || 200;
                 if (this.debug) console.log(`[Bootstrap] Response for stream ${frame.streamId}: ${status}`);
 
@@ -1286,7 +1541,11 @@ class BitBangConnection {
                 if (frame.payload.byteLength > 0 && !(frame.flags & FLAG_SYN)) {
                     req.bytesReceived += frame.payload.byteLength;
                     const data = new Uint8Array(frame.payload);
-                    req.responsePort.postMessage({ type: 'chunk', data }, [data.buffer]);
+                    req.responsePort.postMessage({
+                        type: 'chunk', data, wireBytes: frame.payload.byteLength,
+                    }, [data.buffer]);
+                } else if (!(frame.flags & FLAG_SYN)) {
+                    this._consumeFrame(frame.streamId, 0);
                 }
 
                 // Log completion for large transfers
@@ -1298,12 +1557,25 @@ class BitBangConnection {
                 }
 
                 req.responsePort.postMessage({ type: 'done' });
-                this.pendingRequests.delete(frame.streamId);
+                req.remoteFinished = true;
+                req.cleanupTimeout = setTimeout(() => {
+                    const current = this.pendingRequests.get(frame.streamId);
+                    if (!current) return;
+                    if (current.localFinished) {
+                        this.pendingRequests.delete(frame.streamId);
+                        this.flow.resetStream(frame.streamId, new Error('stream complete'));
+                    } else {
+                        this._resetStream(
+                            frame.streamId, 'timeout', 'request body did not finish', true);
+                    }
+                }, 30000);
             } else if (!(frame.flags & FLAG_SYN) && frame.payload.byteLength > 0) {
                 // Data chunk - use transferable to avoid copy
                 req.bytesReceived += frame.payload.byteLength;
                 const data = new Uint8Array(frame.payload);
-                req.responsePort.postMessage({ type: 'chunk', data }, [data.buffer]);
+                req.responsePort.postMessage({
+                    type: 'chunk', data, wireBytes: frame.payload.byteLength,
+                }, [data.buffer]);
 
                 // Log progress at each 50MB milestone
                 const currentMB = req.bytesReceived / (1024 * 1024);
@@ -1313,6 +1585,10 @@ class BitBangConnection {
                     console.log(`Download: ${currentMB.toFixed(0)} MB (${speed} MB/s)`);
                     req.nextLogMB += 50;
                 }
+            } else if (!(frame.flags & FLAG_SYN)) {
+                // Empty DAT still occupies a receive-frame slot. It carries no
+                // application data, so consume it immediately.
+                this._consumeFrame(frame.streamId, 0);
             }
         } catch (e) {
             console.error('Error parsing SWSP frame:', e);
@@ -1362,7 +1638,21 @@ class BitBangConnection {
             // `server_version` tells us which SWSP version the listener
             // is speaking. v2 listeners send just {type:'ready'} —
             // serverVersion defaults to 2.
-            this.serverVersion = msg.server_version || 2;
+            if (!this._protocolReady) {
+                let versions;
+                try {
+                    versions = SWSPFlowControl.negotiateVersion(
+                        msg.server_version, msg.negotiated_version);
+                } catch (e) {
+                    this.showErrorScreen('Connection rejected: invalid protocol negotiation.');
+                    try { this.dataChannel.close(); } catch (e) {}
+                    return;
+                }
+                this.serverVersion = versions.serverVersion;
+                this.negotiatedVersion = versions.negotiatedVersion;
+                this.flow.reset(this.negotiatedVersion >= SWSP_VERSION);
+                this._protocolReady = true;
+            }
             // routing tells us how to interpret the first segment of the
             // URL fragment's device path. "target-prefix" (bitbangproxy)
             // means the first segment is a LAN target that isolates
@@ -1405,10 +1695,8 @@ class BitBangConnection {
                     if (this._lastPIN) {
                         sessionStorage.setItem('__bb_pin_' + this.uid, this._lastPIN);
                     }
-                    if (this.connectResolve) {
-                        this.connectResolve();
-                        this.connectResolve = null;
-                    }
+                    // The following ready frame completes version
+                    // negotiation and resolves the connect wait.
                 } else {
                     sessionStorage.removeItem('__bb_pin_' + this.uid);
                     this._authRetry = false;
@@ -1422,6 +1710,21 @@ class BitBangConnection {
                 const delay = msg.success ? 2000 : 3000;
                 setTimeout(handleResult, delay);
             }
+        } else if (msg.type === 'window_update') {
+            if (this.negotiatedVersion < SWSP_VERSION) return;
+            if (!this._validStreamId(msg.stream_id)) return;
+            if (this.flow.has(msg.stream_id)
+                && !this.flow.updateWindow(msg.stream_id, msg.max_bytes)) {
+                this._resetStream(msg.stream_id, 'protocol_error', 'invalid window update', true);
+            }
+        } else if (msg.type === 'stream_reset') {
+            if (this.negotiatedVersion < SWSP_VERSION || !this._validStreamId(msg.stream_id)) return;
+            this._resetStream(
+                msg.stream_id,
+                typeof msg.code === 'string' ? msg.code : 'stream_reset',
+                typeof msg.message === 'string' ? msg.message : 'stream reset',
+                false
+            );
         } else if (msg.type === 'video_offer') {
             // Secondary "video" PeerConnection: the device relays an external
             // media helper's offer over the (verified) data channel. We answer
@@ -1548,6 +1851,59 @@ class BitBangConnection {
         }
     }
 
+    _newWSState(iframe, kind) {
+        return {
+            iframe,
+            kind,
+            localClosing: false,
+            localFinished: false,
+            remoteFinished: false,
+            remoteStarted: false,
+            _deliveryPending: false,
+            _pendingFrames: [],
+            _receiveAcks: new Map(),
+        };
+    }
+
+    _finishWSStream(streamId, ws) {
+        if (!ws.localFinished || !ws.remoteFinished
+            || this.wsStreams.get(streamId) !== ws) return;
+        if (ws._closeTimeout) clearTimeout(ws._closeTimeout);
+        ws._receiveAcks.clear();
+        ws._pendingFrames.length = 0;
+        this.wsStreams.delete(streamId);
+        this.flow.resetStream(streamId, new Error('WebSocket closed'));
+    }
+
+    _closeWSOutbound(streamId, ws) {
+        if (ws.localClosing || ws.localFinished
+            || this.wsStreams.get(streamId) !== ws) return;
+        ws.localClosing = true;
+        this._queueStreamFrame(streamId, FLAG_FIN, new Uint8Array(0)).then(() => {
+            if (this.wsStreams.get(streamId) !== ws) return;
+            ws.localClosing = false;
+            ws.localFinished = true;
+            this._finishWSStream(streamId, ws);
+            if (!ws.remoteFinished) {
+                ws._closeTimeout = setTimeout(() => {
+                    this._resetStream(streamId, 'timeout', 'WebSocket close timeout', true);
+                }, 30000);
+            }
+        }).catch((e) => {
+            if (this.wsStreams.get(streamId) === ws) {
+                this._resetStream(streamId, 'send_error', e.message || 'WebSocket close failed', true);
+            }
+        });
+    }
+
+    _drainWSFrames(streamId, ws) {
+        while (!ws._deliveryPending && ws._pendingFrames.length > 0
+            && this.wsStreams.get(streamId) === ws) {
+            const frame = ws._pendingFrames.shift();
+            this.handleWSFrame(frame, ws);
+        }
+    }
+
     handleWSFrame(frame, ws) {
         // Generic /__bitbang/<type> streams use raw bytes for DAT and
         // pass the FIN payload through untouched. Per-cap framing
@@ -1559,12 +1915,31 @@ class BitBangConnection {
         }
 
         if (frame.flags & FLAG_SYN) {
+            if (ws.remoteStarted || ws._deliveryPending) {
+                this._resetStream(frame.streamId, 'protocol_error', 'duplicate WebSocket SYN', true);
+                return;
+            }
+            ws.remoteStarted = true;
             // Device acknowledged the WebSocket open
             if (this.debug) console.log(`[Bootstrap] ws SYN ack from device, streamId=${frame.streamId}`);
             ws.iframe.postMessage({ type: 'ws-opened', streamId: frame.streamId }, '*');
         }
 
+        // A native WebSocket message may be arbitrarily large, so its
+        // fragments are streamed into one Blob assembly. Once complete, hold
+        // subsequent frames inside the negotiated receive window until the
+        // iframe has synchronously dispatched that message. SYN is validated
+        // above because it is credit-exempt and must never enter this queue.
+        if (ws._deliveryPending) {
+            ws._pendingFrames.push(frame);
+            return;
+        }
+
         if (frame.flags & FLAG_FIN) {
+            if (ws._rxParts) {
+                this._resetStream(frame.streamId, 'protocol_error', 'WebSocket closed mid-message', true);
+                return;
+            }
             // Device closed the WebSocket. Parse the JSON close-info payload
             // (added in adapter.py) for the actual close code + reason from
             // the upstream WS. Fall back to 1006 if missing or malformed --
@@ -1579,55 +1954,73 @@ class BitBangConnection {
                     if (typeof info.reason === 'string') reason = info.reason;
                 } catch (e) {}
             }
+            if (!(frame.flags & FLAG_SYN)) {
+                this._consumeFrame(frame.streamId, frame.payload?.byteLength || 0);
+            }
             if (this.debug) console.log(`[Bootstrap] ws FIN from device, streamId=${frame.streamId} code=${code} reason=${JSON.stringify(reason)}`);
-            this.wsStreams.delete(frame.streamId);
-            ws.iframe.postMessage({
-                type: 'ws-closed',
-                streamId: frame.streamId,
-                code,
-                reason
-            }, '*');
+            const close = () => {
+                if (this.wsStreams.get(frame.streamId) !== ws) return;
+                ws.remoteFinished = true;
+                ws.iframe.postMessage({
+                    type: 'ws-closed', streamId: frame.streamId, code, reason,
+                }, '*');
+                this._closeWSOutbound(frame.streamId, ws);
+                this._finishWSStream(frame.streamId, ws);
+            };
+            if (ws._delivery) ws._delivery.then(close, close);
+            else close();
             return;
         }
 
-        if (frame.payload.byteLength > 0 && !(frame.flags & FLAG_SYN)) {
-            // DAT frame(s): a large WS message is split into <=SWSP_CHUNK_SIZE
-            // chunks, with FLAG_MORE on every non-final chunk. Buffer until the
-            // final chunk, then deliver the reassembled message -- preserving the
-            // WS message boundary. The type byte (0=text, 1=binary) rides in the
-            // first chunk.
+        if (!(frame.flags & FLAG_SYN)
+            && (frame.payload.byteLength > 0 || ws._rxParts)) {
+            // Keep fragments as Blob parts so large messages incur one final
+            // materialization rather than repeated whole-buffer copies. Credit
+            // is returned as each fragment enters this application-owned
+            // assembly; the WebSocket API itself still delivers one message.
             const part = new Uint8Array(frame.payload);
-            if (frame.flags & FLAG_MORE) {
-                (ws._rx || (ws._rx = [])).push(part);
-                return;
-            }
-            let full;
-            if (ws._rx) {
-                ws._rx.push(part);
-                const total = ws._rx.reduce((n, a) => n + a.byteLength, 0);
-                full = new Uint8Array(total);
-                let o = 0;
-                for (const a of ws._rx) { full.set(a, o); o += a.byteLength; }
-                ws._rx = null;
+            if (!ws._rxParts) {
+                if (part.byteLength < 1) {
+                    this._resetStream(frame.streamId, 'protocol_error', 'WebSocket message missing type', true);
+                    return;
+                }
+                if (part[0] !== 0 && part[0] !== 1) {
+                    this._resetStream(frame.streamId, 'protocol_error', 'invalid WebSocket message type', true);
+                    return;
+                }
+                ws._rxText = part[0] === 0;
+                ws._rxParts = [part.subarray(1)];
             } else {
-                full = part;
+                ws._rxParts.push(part);
             }
+            this._consumeFrame(frame.streamId, frame.payload.byteLength);
+            if (frame.flags & FLAG_MORE) return;
 
-            const isText = full[0] === 0;
-            const messageBytes = full.slice(1);
-
-            let data;
-            if (isText) {
-                data = new TextDecoder().decode(messageBytes);
-            } else {
-                data = messageBytes.buffer;
-            }
-
-            ws.iframe.postMessage({
-                type: 'ws-message',
-                streamId: frame.streamId,
-                data
-            }, '*');
+            const parts = ws._rxParts;
+            const isText = ws._rxText;
+            ws._rxParts = null;
+            ws._rxText = false;
+            ws._deliveryPending = true;
+            const delivery = (ws._delivery || Promise.resolve()).then(async () => {
+                const blob = new Blob(parts);
+                const data = isText ? await blob.text() : await blob.arrayBuffer();
+                if (this.wsStreams.get(frame.streamId) !== ws) return;
+                const ackToken = this._registerWSAck(ws, 0, 0, () => {
+                    if (this.wsStreams.get(frame.streamId) !== ws) return;
+                    ws._deliveryPending = false;
+                    this._drainWSFrames(frame.streamId, ws);
+                });
+                ws.iframe.postMessage({
+                    type: 'ws-message', streamId: frame.streamId, data, ackToken,
+                }, '*');
+            });
+            ws._delivery = delivery.catch((e) => {
+                this._resetStream(frame.streamId, 'receive_error', e.message || 'message delivery failed', true);
+            });
+            return;
+        }
+        if (!(frame.flags & (FLAG_SYN | FLAG_FIN))) {
+            this._resetStream(frame.streamId, 'protocol_error', 'WebSocket message missing type', true);
         }
     }
 
@@ -1639,6 +2032,11 @@ class BitBangConnection {
     // iframe's WebSocket shim.
     handleBitbangFrame(frame, ws) {
         if (frame.flags & FLAG_SYN) {
+            if (ws.remoteStarted) {
+                this._resetStream(frame.streamId, 'protocol_error', 'duplicate stream SYN', true);
+                return;
+            }
+            ws.remoteStarted = true;
             // A mid-stream SYN from the device is the listener's
             // chosen way to deliver an early-error payload (or any
             // other one-shot metadata). Deliver as a text WS message
@@ -1649,7 +2047,7 @@ class BitBangConnection {
             ws.iframe.postMessage({
                 type: 'ws-message', streamId: frame.streamId, data: text,
             }, '*');
-            return;
+            if (!(frame.flags & FLAG_FIN)) return;
         }
 
         if (frame.flags & FLAG_FIN) {
@@ -1662,21 +2060,31 @@ class BitBangConnection {
             if (frame.payload && frame.payload.byteLength > 0) {
                 reason = new TextDecoder().decode(frame.payload);
             }
-            this.wsStreams.delete(frame.streamId);
+            if (!(frame.flags & FLAG_SYN)) {
+                this._consumeFrame(frame.streamId, frame.payload?.byteLength || 0);
+            }
+            ws.remoteFinished = true;
             ws.iframe.postMessage({
                 type: 'ws-closed', streamId: frame.streamId, code: 1000, reason,
             }, '*');
+            this._closeWSOutbound(frame.streamId, ws);
+            this._finishWSStream(frame.streamId, ws);
             return;
         }
 
         // DAT — raw bytes through. Send as a binary ws-message; the
         // iframe is responsible for whatever tag-byte or framing
         // scheme its cap uses.
-        if (!frame.payload || frame.payload.byteLength === 0) return;
+        if (!frame.payload || frame.payload.byteLength === 0) {
+            this._consumeFrame(frame.streamId, 0);
+            return;
+        }
         const view = new Uint8Array(frame.payload);
         const ab = view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength);
+        const ackToken = this._registerWSAck(ws, frame.payload.byteLength, 1);
         ws.iframe.postMessage({
             type: 'ws-message', streamId: frame.streamId, data: ab,
+            ackToken,
         }, '*');
     }
 
@@ -1692,7 +2100,7 @@ class BitBangConnection {
         const connectMsg = JSON.stringify({
             type: 'connect',
             path: this.devicePath,
-            version: 3,
+            version: SWSP_VERSION,
         });
         this.dataChannel.send(this.createFrame(0, FLAG_SYN, connectMsg));
 
@@ -1812,7 +2220,7 @@ class BitBangConnection {
         const connectMsg = JSON.stringify({
             type: 'connect',
             path,
-            version: 3,
+            version: SWSP_VERSION,
         });
         this.dataChannel.send(this.createFrame(0, FLAG_SYN, connectMsg));
     }
@@ -1820,13 +2228,21 @@ class BitBangConnection {
     handleWSShimMessage(event) {
         const iframe = document.getElementById('device-frame');
         if (!iframe || event.source !== iframe.contentWindow) return;
-        if (!this.dataChannel || this.dataChannel.readyState !== 'open') return;
-
         const msg = event.data;
         if (!msg || !msg.type?.startsWith('ws-')) return;
+        if (!this.dataChannel || this.dataChannel.readyState !== 'open'
+            || !this.deviceVerified || !this._protocolReady) {
+            if (msg.type === 'ws-open') {
+                iframe.contentWindow.postMessage({
+                    type: 'ws-rejected', requestId: msg.requestId,
+                    message: 'Connection not ready',
+                }, '*');
+            }
+            return;
+        }
 
         if (msg.type === 'ws-open') {
-            const streamId = this.nextStreamId++;
+            const streamId = this._allocateStreamId();
             if (this.debug) console.log(`[Bootstrap] ws-open ${msg.pathname}, streamId=${streamId}, cookies.len=${(msg.cookies || '').length}`);
 
             // Magic path: /__bitbang/<type>?<params> opens a SWSP
@@ -1848,8 +2264,8 @@ class BitBangConnection {
                 const type = tail.split('/')[0];
                 if (!type) {
                     iframe.contentWindow.postMessage({
-                        type: 'ws-closed', streamId, code: 1008,
-                        reason: 'bitbang: empty type in magic path',
+                        type: 'ws-rejected', requestId: msg.requestId,
+                        message: 'bitbang: empty type in magic path',
                     }, '*');
                     return;
                 }
@@ -1865,11 +2281,17 @@ class BitBangConnection {
                     catch (e) { syn[k] = v; }
                 }
 
-                this.wsStreams.set(streamId, { iframe: iframe.contentWindow, kind: 'bitbang' });
+                this.wsStreams.set(streamId, this._newWSState(iframe.contentWindow, 'bitbang'));
                 iframe.contentWindow.postMessage({
-                    type: 'ws-assign', pathname: msg.pathname, streamId,
+                    type: 'ws-assign', requestId: msg.requestId,
+                    pathname: msg.pathname, streamId,
                 }, '*');
-                this.dataChannel.send(this.createFrame(streamId, FLAG_SYN, JSON.stringify(syn)));
+                try {
+                    this._sendStreamSYN(streamId, FLAG_SYN, JSON.stringify(syn));
+                } catch (e) {
+                    this._resetStream(streamId, 'send_error', 'Failed to open stream', false);
+                    return;
+                }
                 // Tell the iframe the WS is open now. Listener handlers
                 // typically don't send a SYN ack on the success path —
                 // the first DAT is the natural signal that things are
@@ -1879,9 +2301,10 @@ class BitBangConnection {
             }
 
             // Regular WebSocket proxy path (unchanged).
-            this.wsStreams.set(streamId, { iframe: iframe.contentWindow, kind: 'websocket' });
+            this.wsStreams.set(streamId, this._newWSState(iframe.contentWindow, 'websocket'));
             iframe.contentWindow.postMessage({
                 type: 'ws-assign',
+                requestId: msg.requestId,
                 pathname: msg.pathname,
                 streamId
             }, '*');
@@ -1890,59 +2313,59 @@ class BitBangConnection {
                 pathname: msg.pathname,
                 cookies: msg.cookies || '',
             });
-            this.dataChannel.send(this.createFrame(streamId, FLAG_SYN, synPayload));
+            try {
+                this._sendStreamSYN(streamId, FLAG_SYN, synPayload);
+            } catch (e) {
+                this._resetStream(streamId, 'send_error', 'Failed to open WebSocket', false);
+                return;
+            }
             if (this.debug) console.log(`[Bootstrap] ws SYN sent to device, streamId=${streamId}`);
 
         } else if (msg.type === 'ws-send') {
             const ws = this.wsStreams.get(msg.streamId);
-            if (!ws) return;
-
-            if (ws.kind === 'bitbang') {
-                // Generic shuttle: raw bytes go through unchanged. Text
-                // frames are UTF-8 encoded; the iframe is responsible
-                // for keeping the cap-specific framing it expects.
-                let payload;
+            if (!ws || ws.localClosing || ws.localFinished) return;
+            (async () => {
+                let raw;
                 if (msg.isText) {
-                    payload = new TextEncoder().encode(msg.data);
+                    raw = new TextEncoder().encode(msg.data);
+                } else if (msg.data instanceof Blob) {
+                    raw = new Uint8Array(await msg.data.arrayBuffer());
                 } else {
-                    payload = msg.data instanceof ArrayBuffer
-                        ? new Uint8Array(msg.data)
-                        : new Uint8Array(msg.data);
+                    raw = SWSPFlowControl.asBytes(msg.data);
                 }
-                this.dataChannel.send(this.createFrame(msg.streamId, FLAG_DAT, payload));
-                return;
-            }
 
-            // Regular WebSocket DAT framing: [1B type: 0=text 1=binary][message]
-            let payload;
-            if (msg.isText) {
-                const textBytes = new TextEncoder().encode(msg.data);
-                payload = new Uint8Array(1 + textBytes.length);
-                payload[0] = 0; // text
-                payload.set(textBytes, 1);
-            } else {
-                const binBytes = msg.data instanceof ArrayBuffer
-                    ? new Uint8Array(msg.data)
-                    : new Uint8Array(msg.data);
-                payload = new Uint8Array(1 + binBytes.length);
-                payload[0] = 1; // binary
-                payload.set(binBytes, 1);
-            }
-            // Chunk at SWSP_CHUNK_SIZE (the data-channel message limit). Non-final
-            // chunks carry FLAG_MORE so the device reassembles them into one WS
-            // message (the type byte rides in the first chunk).
-            for (let off = 0; off < payload.length; off += SWSP_CHUNK_SIZE) {
-                const end = off + SWSP_CHUNK_SIZE;
-                const flags = end >= payload.length ? FLAG_DAT : (FLAG_DAT | FLAG_MORE);
-                this.dataChannel.send(this.createFrame(
-                    msg.streamId, flags, payload.subarray(off, Math.min(end, payload.length))));
-            }
+                let payload = raw;
+                if (ws.kind === 'websocket') {
+                    // Regular WebSocket framing: [1B type][message].
+                    payload = new Uint8Array(1 + raw.length);
+                    payload[0] = msg.isText ? 0 : 1;
+                    payload.set(raw, 1);
+                }
+
+                for (let off = 0; off < payload.length; off += SWSP_CHUNK_SIZE) {
+                    const end = Math.min(off + SWSP_CHUNK_SIZE, payload.length);
+                    const flags = ws.kind === 'websocket' && end < payload.length
+                        ? (FLAG_DAT | FLAG_MORE) : FLAG_DAT;
+                    await this._queueStreamFrame(
+                        msg.streamId, flags, payload.subarray(off, end));
+                }
+                if (payload.length === 0) {
+                    await this._queueStreamFrame(msg.streamId, FLAG_DAT, payload);
+                }
+                ws.iframe.postMessage({
+                    type: 'ws-send-ack', streamId: msg.streamId,
+                    bytes: msg.bufferedBytes || raw.byteLength,
+                }, '*');
+            })().catch((e) => {
+                this._resetStream(msg.streamId, 'send_error', e.message || 'send failed', true);
+            });
 
         } else if (msg.type === 'ws-close') {
             const ws = this.wsStreams.get(msg.streamId);
             if (!ws) return;
-            this.wsStreams.delete(msg.streamId);
-            this.dataChannel.send(this.createFrame(msg.streamId, FLAG_FIN, new Uint8Array(0)));
+            this._closeWSOutbound(msg.streamId, ws);
+        } else if (msg.type === 'ws-consumed') {
+            this._handleWSAck(msg.streamId, msg.ackToken);
         }
     }
 

--- a/bitbang-server/web/flow-control.js
+++ b/bitbang-server/web/flow-control.js
@@ -14,6 +14,8 @@
     const VERSION = 4;
     const WINDOW_BYTES = 1024 * 1024;
     const UPDATE_BYTES = WINDOW_BYTES / 2;
+    // The byte window caps payload memory; this separately bounds queue and
+    // dispatch work for tiny or empty frames that consume little byte credit.
     const MAX_PENDING_FRAMES = 256;
     const MAX_PAYLOAD_BYTES = 32768;
 
@@ -97,8 +99,8 @@
             let state = this.streams.get(streamId);
             if (state) return state;
             state = {
-                advertised: false,
-                sendLimit: this.enabled ? 0 : Number.MAX_SAFE_INTEGER,
+                // A v4 SYN opens both directions with this implicit credit.
+                sendLimit: this.enabled ? WINDOW_BYTES : Number.MAX_SAFE_INTEGER,
                 sentBytes: 0,
                 sendWaiters: [],
                 recvLimit: WINDOW_BYTES,
@@ -114,20 +116,6 @@
 
         has(streamId) {
             return this.streams.has(streamId);
-        }
-
-        advertise(streamId) {
-            if (!this.enabled) return true;
-            if (this.closed) return false;
-            const state = this.open(streamId);
-            if (state.advertised) return true;
-            if (!this.sendControl({
-                type: 'window_update',
-                stream_id: streamId,
-                max_bytes: state.recvLimit,
-            })) return false;
-            state.advertised = true;
-            return true;
         }
 
         updateWindow(streamId, maxBytes) {

--- a/bitbang-server/web/flow-control.js
+++ b/bitbang-server/web/flow-control.js
@@ -1,0 +1,257 @@
+/**
+ * Per-stream SWSP v4 credit accounting.
+ *
+ * The transport owns when bytes are considered consumed; this helper only
+ * keeps the cumulative send/receive limits and wakes ordered send waiters.
+ */
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.SWSPFlowControl = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const VERSION = 4;
+    const WINDOW_BYTES = 1024 * 1024;
+    const UPDATE_BYTES = WINDOW_BYTES / 2;
+    const MAX_PENDING_FRAMES = 256;
+    const MAX_PAYLOAD_BYTES = 32768;
+
+    function negotiateVersion(serverVersion, selectedVersion) {
+        const server = serverVersion === undefined || serverVersion === null || serverVersion === 0
+            ? 2 : serverVersion;
+        if (!Number.isSafeInteger(server) || server < 2) {
+            throw new FlowError('protocol_error', 'unsupported SWSP server version');
+        }
+        const maximum = Math.min(VERSION, server);
+        const selected = selectedVersion === undefined || selectedVersion === null
+            ? maximum : selectedVersion;
+        if (!Number.isSafeInteger(selected) || selected < 2 || selected > maximum) {
+            throw new FlowError('protocol_error', 'invalid SWSP version negotiation');
+        }
+        return { serverVersion: server, negotiatedVersion: selected };
+    }
+
+    function asBytes(value) {
+        if (value instanceof ArrayBuffer) return new Uint8Array(value);
+        if (ArrayBuffer.isView(value)) {
+            return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+        }
+        throw new TypeError('expected ArrayBuffer or ArrayBufferView');
+    }
+
+    function createFrame(streamId, flags, payload) {
+        const payloadBytes = typeof payload === 'string'
+            ? new TextEncoder().encode(payload) : asBytes(payload);
+        if (payloadBytes.byteLength > MAX_PAYLOAD_BYTES) {
+            throw new RangeError('SWSP payload exceeds frame limit');
+        }
+        const buffer = new ArrayBuffer(8 + payloadBytes.byteLength);
+        const view = new DataView(buffer);
+        view.setUint32(0, streamId, true);
+        view.setUint16(4, flags, true);
+        view.setUint16(6, payloadBytes.byteLength, true);
+        new Uint8Array(buffer, 8).set(payloadBytes);
+        return buffer;
+    }
+
+    function parseFrame(buffer) {
+        const bytes = asBytes(buffer);
+        if (bytes.byteLength < 8) throw new RangeError('SWSP frame is truncated');
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const streamId = view.getUint32(0, true);
+        const flags = view.getUint16(4, true);
+        const length = view.getUint16(6, true);
+        if (bytes.byteLength !== 8 + length) {
+            throw new RangeError('SWSP frame length does not match payload');
+        }
+        const payload = bytes.buffer.slice(
+            bytes.byteOffset + 8, bytes.byteOffset + 8 + length);
+        return { streamId, flags, payload };
+    }
+
+    class FlowError extends Error {
+        constructor(code, message) {
+            super(message);
+            this.name = 'FlowError';
+            this.code = code;
+        }
+    }
+
+    class Controller {
+        constructor(sendControl) {
+            this.sendControl = sendControl;
+            this.enabled = false;
+            this.closed = false;
+            this.streams = new Map();
+        }
+
+        reset(enabled) {
+            this.close(new FlowError('session_closed', 'session reset'));
+            this.enabled = !!enabled;
+            this.closed = false;
+            this.streams = new Map();
+        }
+
+        open(streamId) {
+            let state = this.streams.get(streamId);
+            if (state) return state;
+            state = {
+                advertised: false,
+                sendLimit: this.enabled ? 0 : Number.MAX_SAFE_INTEGER,
+                sentBytes: 0,
+                sendWaiters: [],
+                recvLimit: WINDOW_BYTES,
+                recvBytes: 0,
+                consumedBytes: 0,
+                lastUpdateBytes: 0,
+                pendingFrames: 0,
+                receiveEnded: false,
+            };
+            this.streams.set(streamId, state);
+            return state;
+        }
+
+        has(streamId) {
+            return this.streams.has(streamId);
+        }
+
+        advertise(streamId) {
+            if (!this.enabled) return true;
+            if (this.closed) return false;
+            const state = this.open(streamId);
+            if (state.advertised) return true;
+            if (!this.sendControl({
+                type: 'window_update',
+                stream_id: streamId,
+                max_bytes: state.recvLimit,
+            })) return false;
+            state.advertised = true;
+            return true;
+        }
+
+        updateWindow(streamId, maxBytes) {
+            if (!this.enabled) return true;
+            const state = this.streams.get(streamId);
+            if (!state) return false;
+            if (!Number.isSafeInteger(maxBytes) || maxBytes <= 0) return false;
+            if (maxBytes <= state.sendLimit) return true;
+            state.sendLimit = maxBytes;
+            this._wake(state);
+            return true;
+        }
+
+        waitToSend(streamId, byteLength) {
+            if (!Number.isSafeInteger(byteLength) || byteLength < 0 || byteLength > WINDOW_BYTES) {
+                return Promise.reject(new FlowError('protocol_error', 'invalid SWSP frame size'));
+            }
+            if (this.closed) {
+                return Promise.reject(new FlowError('session_closed', 'session closed'));
+            }
+            const state = this.streams.get(streamId);
+            if (!state) {
+                return Promise.reject(new FlowError('protocol_error', 'data sent before SYN'));
+            }
+            if (!this.enabled || byteLength === 0) return Promise.resolve();
+            return new Promise((resolve, reject) => {
+                state.sendWaiters.push({ byteLength, resolve, reject });
+                this._wake(state);
+            });
+        }
+
+        receive(streamId, byteLength, final) {
+            const state = this.streams.get(streamId);
+            if (!state || state.receiveEnded) return false;
+            if (final) state.receiveEnded = true;
+            if (!Number.isSafeInteger(byteLength) || byteLength < 0) return false;
+            if (state.pendingFrames >= MAX_PENDING_FRAMES) return false;
+            if (state.recvBytes + byteLength > state.recvLimit) return false;
+            state.recvBytes += byteLength;
+            state.pendingFrames++;
+            return true;
+        }
+
+        finishReceive(streamId) {
+            const state = this.streams.get(streamId);
+            if (!state || state.receiveEnded) return false;
+            state.receiveEnded = true;
+            return true;
+        }
+
+        consume(streamId, byteLength, frames) {
+            const state = this.streams.get(streamId);
+            if (!state || !Number.isSafeInteger(byteLength) || byteLength < 0) return false;
+            const frameCount = frames === undefined ? 1 : frames;
+            if (!Number.isSafeInteger(frameCount) || frameCount <= 0
+                || frameCount > state.pendingFrames
+                || byteLength > state.recvBytes - state.consumedBytes) {
+                return false;
+            }
+            state.pendingFrames -= frameCount;
+            if (byteLength === 0) return true;
+            state.consumedBytes += byteLength;
+            if (!this.enabled) {
+                // Legacy peers do not understand window updates, but local
+                // queues must remain bounded. Slide the private receive limit
+                // as the application consumes data without sending a control.
+                state.recvLimit = state.consumedBytes + WINDOW_BYTES;
+                return true;
+            }
+            if (state.consumedBytes - state.lastUpdateBytes < UPDATE_BYTES) return true;
+            const recvLimit = state.consumedBytes + WINDOW_BYTES;
+            if (!this.sendControl({
+                type: 'window_update',
+                stream_id: streamId,
+                max_bytes: recvLimit,
+            })) return false;
+            state.lastUpdateBytes = state.consumedBytes;
+            state.recvLimit = recvLimit;
+            return true;
+        }
+
+        resetStream(streamId, error) {
+            const state = this.streams.get(streamId);
+            if (!state) return;
+            const err = error instanceof Error
+                ? error
+                : new FlowError('stream_reset', String(error || 'stream reset'));
+            this.streams.delete(streamId);
+            for (const waiter of state.sendWaiters) waiter.reject(err);
+            state.sendWaiters.length = 0;
+        }
+
+        close(error) {
+            const err = error instanceof Error
+                ? error
+                : new FlowError('session_closed', String(error || 'session closed'));
+            this.closed = true;
+            for (const streamId of Array.from(this.streams.keys())) {
+                this.resetStream(streamId, err);
+            }
+        }
+
+        _wake(state) {
+            while (state.sendWaiters.length > 0) {
+                const waiter = state.sendWaiters[0];
+                if (state.sentBytes + waiter.byteLength > state.sendLimit) return;
+                state.sendWaiters.shift();
+                state.sentBytes += waiter.byteLength;
+                waiter.resolve();
+            }
+        }
+    }
+
+    return {
+        VERSION,
+        WINDOW_BYTES,
+        UPDATE_BYTES,
+        MAX_PENDING_FRAMES,
+        MAX_PAYLOAD_BYTES,
+        negotiateVersion,
+        asBytes,
+        createFrame,
+        parseFrame,
+        FlowError,
+        Controller,
+    };
+});

--- a/bitbang-server/web/sw-upload.js
+++ b/bitbang-server/web/sw-upload.js
@@ -1,0 +1,72 @@
+/**
+ * Bounded request-body transfer and acknowledgement state for sw.js.
+ */
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.SWSPUpload = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const MAX_SLICE_BYTES = 1024 * 1024;
+
+    function copySlice(value, offset) {
+        if (!ArrayBuffer.isView(value)) {
+            throw new TypeError('request body chunk must be an ArrayBuffer view');
+        }
+        if (!Number.isSafeInteger(offset) || offset < 0 || offset >= value.byteLength) {
+            throw new RangeError('invalid request body chunk offset');
+        }
+        const bytes = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+        return bytes.slice(offset, Math.min(offset + MAX_SLICE_BYTES, bytes.byteLength));
+    }
+
+    class AckGate {
+        constructor(timeoutMs = 30000) {
+            this.timeoutMs = timeoutMs;
+            this.pending = null;
+            this.error = null;
+        }
+
+        wait(seq) {
+            if (this.error) return Promise.reject(this.error);
+            if (this.pending) {
+                return Promise.reject(new Error('upload acknowledgement already pending'));
+            }
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    this.fail(new Error('upload backpressure timeout'));
+                }, this.timeoutMs);
+                this.pending = { seq, resolve, reject, timer };
+            });
+        }
+
+        acknowledge(seq) {
+            if (!this.pending || seq !== this.pending.seq) return false;
+            const pending = this.pending;
+            this.pending = null;
+            clearTimeout(pending.timer);
+            pending.resolve();
+            return true;
+        }
+
+        fail(error) {
+            if (!this.error) {
+                this.error = error instanceof Error ? error : new Error(String(error));
+            }
+            if (this.pending) {
+                const pending = this.pending;
+                this.pending = null;
+                clearTimeout(pending.timer);
+                pending.reject(this.error);
+            }
+            return this.error;
+        }
+
+        throwIfFailed() {
+            if (this.error) throw this.error;
+        }
+    }
+
+    return { MAX_SLICE_BYTES, copySlice, AckGate };
+});

--- a/bitbang-server/web/sw.js
+++ b/bitbang-server/web/sw.js
@@ -7,6 +7,8 @@
  * are rewritten at the source by xhr-shim.js.
  */
 
+importScripts('/__bitbang__/sw-upload.js');
+
 console.log('[SW] booted');
 
 self.addEventListener('install', () => self.skipWaiting());
@@ -999,37 +1001,111 @@ async function proxyToDevice(event) {
         contentLength
     }, [channel.port2]);
 
-    // -- Stream request body (if any) --
-    if (hasBody) {
-        if (event.request.body) {
-            const reader = event.request.body.getReader();
-            try {
-                while (true) {
-                    const { done, value } = await reader.read();
-                    if (done) break;
-                    channel.port1.postMessage({ type: 'bodyChunk', data: value }, [value.buffer]);
-                }
-            } finally {
-                reader.releaseLock();
+    // Upload acknowledgements and response frames share this MessagePort.
+    // Install a router before reading the request body so an ack cannot race
+    // the response handler setup. Non-ack messages are retained until the
+    // response promise below is ready to consume them.
+    const uploadAcks = new SWSPUpload.AckGate(30000);
+    let bodyReader = null;
+    let responseHandler = null;
+    const pendingResponseMessages = [];
+    channel.port1.onmessage = (msg) => {
+        if (msg.data?.type === 'bodyAck') {
+            if (uploadAcks.acknowledge(msg.data.seq)) return;
+        }
+        if (msg.data?.type === 'error') {
+            const error = uploadAcks.fail(new Error(msg.data.message || 'upload failed'));
+            if (bodyReader) {
+                Promise.resolve(bodyReader.cancel(error)).catch(() => {});
             }
         }
-        channel.port1.postMessage({ type: 'bodyEnd' });
+        if (responseHandler) responseHandler(msg);
+        else pendingResponseMessages.push(msg);
+    };
+
+    // -- Stream request body (if any) --
+    if (hasBody) {
+        try {
+            if (event.request.body) {
+                bodyReader = event.request.body.getReader();
+                let seq = 0;
+                try {
+                    while (true) {
+                        const { done, value } = await bodyReader.read();
+                        uploadAcks.throwIfFailed();
+                        if (done) break;
+
+                        for (let offset = 0; offset < value.byteLength;) {
+                            uploadAcks.throwIfFailed();
+                            const chunk = SWSPUpload.copySlice(value, offset);
+                            offset += chunk.byteLength;
+                            seq++;
+                            const ack = uploadAcks.wait(seq);
+                            channel.port1.postMessage({
+                                type: 'bodyChunk', data: chunk, seq,
+                            }, [chunk.buffer]);
+                            await ack;
+                        }
+                    }
+                } finally {
+                    bodyReader.releaseLock();
+                    bodyReader = null;
+                }
+            }
+            uploadAcks.throwIfFailed();
+            channel.port1.postMessage({ type: 'bodyEnd' });
+        } catch (e) {
+            channel.port1.postMessage({
+                type: 'cancel', message: e.message || 'upload failed',
+            });
+            return new Response(`BitBang: ${e.message || 'upload failed'}`, { status: 500 });
+        }
     }
 
     // -- Stream response back to browser --
     return new Promise((resolve) => {
         let streamController;
         let resolved = false;
+        let responseDone = false;
+        let responseClosed = false;
+        const responseChunks = [];
         let timeout;
+        const closeResponsePort = () => {
+            if (responseClosed) return;
+            responseClosed = true;
+            channel.port1.postMessage({ type: 'responseClosed' });
+        };
+        const pumpResponse = () => {
+            if (!streamController) return;
+            try {
+                while (responseChunks.length > 0 && streamController.desiredSize > 0) {
+                    const chunk = responseChunks.shift();
+                    streamController.enqueue(chunk.data);
+                    if (chunk.wireBytes) {
+                        channel.port1.postMessage({
+                            type: 'responseConsumed', bytes: chunk.wireBytes, frames: 1,
+                        });
+                    }
+                }
+                if (responseDone && responseChunks.length === 0) {
+                    streamController.close();
+                    closeResponsePort();
+                }
+            } catch (e) {
+                channel.port1.postMessage({ type: 'cancel', message: String(e) });
+                closeResponsePort();
+            }
+        };
         if (!hasBody) {
             timeout = setTimeout(() => {
                 if (!resolved) {
+                    channel.port1.postMessage({ type: 'cancel', message: 'request timeout' });
                     resolve(new Response('BitBang: request timeout', { status: 504 }));
                 }
             }, 30000);
         }
 
-        channel.port1.onmessage = (msg) => {
+        responseHandler = (msg) => {
             const { type, status, headers, data, message } = msg.data;
 
             if (type === 'uploadProgress') {
@@ -1140,7 +1216,18 @@ async function proxyToDevice(event) {
                                 + '<script src="/__bitbang__/ws-shim.js"></script>';
                             controller.enqueue(new TextEncoder().encode(shims));
                         }
-                    }
+                        pumpResponse();
+                    },
+                    pull() {
+                        pumpResponse();
+                    },
+                    cancel(reason) {
+                        responseChunks.length = 0;
+                        channel.port1.postMessage({
+                            type: 'cancel', message: String(reason || 'response cancelled'),
+                        });
+                        closeResponsePort();
+                    },
                 });
 
                 // CORS headers for fonts with crossorigin attributes
@@ -1152,17 +1239,22 @@ async function proxyToDevice(event) {
                 const nullBodyStatus = (status === 204 || status === 304);
                 resolve(new Response(nullBodyStatus ? null : stream, { status, headers }));
             } else if (type === 'chunk') {
-                try { streamController?.enqueue(data); } catch (e) {}
+                responseChunks.push({ data, wireBytes: msg.data.wireBytes || 0 });
+                pumpResponse();
             } else if (type === 'done') {
-                try { streamController?.close(); } catch (e) {}
+                responseDone = true;
+                pumpResponse();
             } else if (type === 'error') {
                 if (timeout) clearTimeout(timeout);
+                responseChunks.length = 0;
                 if (!resolved) {
                     resolve(new Response(`BitBang: ${message}`, { status: 500 }));
                 } else {
                     try { streamController?.error(new Error(message)); } catch (e) {}
                 }
+                closeResponsePort();
             }
         };
+        for (const msg of pendingResponseMessages.splice(0)) responseHandler(msg);
     });
 }

--- a/bitbang-server/web/ws-shim.js
+++ b/bitbang-server/web/ws-shim.js
@@ -16,6 +16,8 @@
 
     // Registry of active shim WebSockets by streamId
     const sockets = new Map();
+    const pendingSockets = new Map();
+    let nextRequestId = 1;
 
     // Mirror SW cookie-jar updates into document.cookie so app code that
     // reads cookies directly (CSRF tokens, etc.) sees fresh values after
@@ -59,23 +61,62 @@
     // Listen for messages from the bootstrap parent
     window.addEventListener('message', (event) => {
         if (event.source !== parent) return;
-        const { type, streamId, data, code, reason, message } = event.data || {};
+        const {
+            type, streamId, requestId, data, code, reason, message, ackToken, bytes,
+        } = event.data || {};
+
+        if (type === 'ws-rejected') {
+            const pending = pendingSockets.get(requestId);
+            if (!pending) return;
+            pendingSockets.delete(requestId);
+            window.removeEventListener('message', pending._assignHandler);
+            pending._readyState = NativeWebSocket.CLOSED;
+            const errorEvent = new Event('error');
+            try {
+                pending.dispatchEvent(errorEvent);
+                if (pending.onerror) pending.onerror(errorEvent);
+            } finally {
+                const closeEvent = new CloseEvent('close', {
+                    code: 1006, reason: message || 'Connection not ready',
+                });
+                pending.dispatchEvent(closeEvent);
+                if (pending.onclose) pending.onclose(closeEvent);
+            }
+            return;
+        }
 
         const ws = sockets.get(streamId);
         if (!ws) return;
 
         if (type === 'ws-opened') {
+            if (ws._readyState !== NativeWebSocket.CONNECTING) return;
             log('ws-opened, streamId=' + streamId);
             ws._readyState = NativeWebSocket.OPEN;
-            ws.dispatchEvent(new Event('open'));
-            if (ws.onopen) ws.onopen(new Event('open'));
-        } else if (type === 'ws-message') {
-            const evt = new MessageEvent('message', { data });
+            const evt = new Event('open');
             ws.dispatchEvent(evt);
-            if (ws.onmessage) ws.onmessage(evt);
+            if (ws.onopen) ws.onopen(evt);
+        } else if (type === 'ws-message') {
+            const messageData = data instanceof ArrayBuffer && ws.binaryType === 'blob'
+                ? new Blob([data]) : data;
+            const evt = new MessageEvent('message', { data: messageData });
+            try {
+                ws.dispatchEvent(evt);
+                if (ws.onmessage) ws.onmessage(evt);
+            } finally {
+                if (ackToken) {
+                    parent.postMessage({
+                        type: 'ws-consumed', streamId, ackToken,
+                    }, '*');
+                }
+            }
+        } else if (type === 'ws-send-ack') {
+            ws._ackSend(bytes || 0);
         } else if (type === 'ws-closed') {
             log('ws-closed, streamId=' + streamId, 'code=' + code);
             ws._readyState = NativeWebSocket.CLOSED;
+            ws._sendQueue.length = 0;
+            ws._bufferedAmount = 0;
+            ws._sendInFlight = false;
             sockets.delete(streamId);
             const evt = new CloseEvent('close', { code: code || 1000, reason: reason || '' });
             ws.dispatchEvent(evt);
@@ -104,6 +145,12 @@
             this.onerror = null;
             this.binaryType = 'blob';
             this._readyState = NativeWebSocket.CONNECTING;
+            this._sendQueue = [];
+            this._sendInFlight = false;
+            this._bufferedAmount = 0;
+            this._closePending = null;
+            this._requestId = nextRequestId++;
+            pendingSockets.set(this._requestId, this);
 
             // Parse URL to get pathname, stripping /__device__ prefix
             let pathname;
@@ -129,46 +176,84 @@
             // which can be stale after AJAX Set-Cookie responses.
             getCookiesFromSW(pathname).then((cookies) => {
                 log('ws-open posted', pathname, 'cookies.len=' + cookies.length);
-                parent.postMessage({ type: 'ws-open', pathname, protocols, cookies }, '*');
+                parent.postMessage({
+                    type: 'ws-open', requestId: this._requestId,
+                    pathname, protocols, cookies,
+                }, '*');
             });
 
             // Bootstrap will respond with ws-assign containing the streamId
             const assignHandler = (event) => {
                 if (event.source !== parent) return;
-                if (event.data?.type === 'ws-assign' && event.data.pathname === pathname) {
+                if (event.data?.type === 'ws-assign'
+                    && event.data.requestId === this._requestId) {
                     window.removeEventListener('message', assignHandler);
+                    pendingSockets.delete(this._requestId);
                     this._streamId = event.data.streamId;
                     sockets.set(this._streamId, this);
                     log('ws-assign received, streamId=' + this._streamId);
+                    this._flushSend();
                 }
             };
+            this._assignHandler = assignHandler;
             window.addEventListener('message', assignHandler);
         }
 
         get readyState() { return this._readyState; }
+        get bufferedAmount() { return this._bufferedAmount; }
 
         send(data) {
             if (this._readyState !== NativeWebSocket.OPEN) {
                 throw new DOMException('WebSocket is not open', 'InvalidStateError');
             }
             const isText = typeof data === 'string';
-            parent.postMessage({
-                type: 'ws-send',
-                streamId: this._streamId,
-                data,
-                isText
-            }, '*');
+            let bytes;
+            if (isText) bytes = new TextEncoder().encode(data).byteLength;
+            else if (data instanceof Blob) bytes = data.size;
+            else if (data instanceof ArrayBuffer) bytes = data.byteLength;
+            else if (ArrayBuffer.isView(data)) bytes = data.byteLength;
+            else throw new TypeError('WebSocket data must be a string, Blob, ArrayBuffer, or ArrayBufferView');
+            this._sendQueue.push({ data, isText, bytes });
+            this._bufferedAmount += bytes;
+            this._flushSend();
         }
 
         close(code, reason) {
             if (this._readyState === NativeWebSocket.CLOSED) return;
             this._readyState = NativeWebSocket.CLOSING;
+            this._closePending = { code: code || 1000, reason: reason || '' };
+            this._flushSend();
+        }
+
+        _flushSend() {
+            if (this._sendInFlight) return;
+            if (this._streamId === undefined) return;
+            const next = this._sendQueue[0];
+            if (next) {
+                this._sendInFlight = true;
+                parent.postMessage({
+                    type: 'ws-send', streamId: this._streamId,
+                    data: next.data, isText: next.isText,
+                    bufferedBytes: next.bytes,
+                }, '*');
+                return;
+            }
+            if (!this._closePending) return;
+            const close = this._closePending;
+            this._closePending = null;
             parent.postMessage({
                 type: 'ws-close',
                 streamId: this._streamId,
-                code: code || 1000,
-                reason: reason || ''
+                code: close.code,
+                reason: close.reason
             }, '*');
+        }
+
+        _ackSend(bytes) {
+            const sent = this._sendQueue.shift();
+            this._bufferedAmount = Math.max(0, this._bufferedAmount - (sent?.bytes || bytes));
+            this._sendInFlight = false;
+            this._flushSend();
         }
 
         // Standard WebSocket constants

--- a/bitbang-server/web_test/flow-control.test.js
+++ b/bitbang-server/web_test/flow-control.test.js
@@ -49,7 +49,7 @@ test('frame codec rejects oversized, truncated, and trailing payloads', () => {
     assert.throws(() => parseFrame(trailing), /does not match/);
 });
 
-test('sender stops at the advertised window and resumes on update', async () => {
+test('sender uses the implicit initial window and resumes on update', async () => {
     const controls = [];
     const flow = new Controller(msg => {
         controls.push(msg);
@@ -57,14 +57,14 @@ test('sender stops at the advertised window and resumes on update', async () => 
     });
     flow.reset(true);
     flow.open(1);
-    flow.advertise(1);
 
-    assert.deepEqual(controls, [{
-        type: 'window_update', stream_id: 1, max_bytes: WINDOW_BYTES,
-    }]);
-
-    assert.equal(flow.updateWindow(1, WINDOW_BYTES), true);
-    await flow.waitToSend(1, WINDOW_BYTES);
+    let initialReleased = false;
+    const initial = flow.waitToSend(1, WINDOW_BYTES)
+        .then(() => { initialReleased = true; });
+    await Promise.resolve();
+    assert.equal(initialReleased, true);
+    await initial;
+    assert.deepEqual(controls, []);
 
     let released = false;
     const blocked = flow.waitToSend(1, 1).then(() => { released = true; });
@@ -84,15 +84,14 @@ test('receive limit is replenished only after the consumption threshold', () => 
     });
     flow.reset(true);
     flow.open(3);
-    flow.advertise(3);
 
     assert.equal(flow.receive(3, UPDATE_BYTES - 1), true);
     flow.consume(3, UPDATE_BYTES - 1);
-    assert.equal(controls.length, 1);
+    assert.equal(controls.length, 0);
 
     assert.equal(flow.receive(3, 1), true);
     flow.consume(3, 1);
-    assert.deepEqual(controls[1], {
+    assert.deepEqual(controls[0], {
         type: 'window_update',
         stream_id: 3,
         max_bytes: WINDOW_BYTES + UPDATE_BYTES,
@@ -153,9 +152,9 @@ test('window updates require a positive maximum', () => {
     assert.equal(flow.updateWindow(1, 0), false);
     assert.equal(flow.updateWindow(1, -1), false);
     assert.equal(flow.updateWindow(1, Number.NaN), false);
-    assert.equal(flow.updateWindow(1, 10), true);
-    assert.equal(flow.updateWindow(1, 5), true);
-    assert.equal(flow.updateWindow(1, 10), true);
+    assert.equal(flow.updateWindow(1, WINDOW_BYTES + 10), true);
+    assert.equal(flow.updateWindow(1, WINDOW_BYTES + 5), true);
+    assert.equal(flow.updateWindow(1, WINDOW_BYTES + 10), true);
 });
 
 test('zero-byte sends still require a live stream', async () => {
@@ -172,6 +171,7 @@ test('reset rejects blocked senders without affecting another stream', async () 
     flow.open(1);
     flow.open(3);
 
+    await flow.waitToSend(1, WINDOW_BYTES);
     const blocked = flow.waitToSend(1, 1);
     flow.resetStream(1, new Error('stalled'));
     await assert.rejects(blocked, /stalled/);
@@ -184,7 +184,6 @@ test('legacy mode never waits for credit', async () => {
     const flow = new Controller(() => assert.fail('legacy mode sent control'));
     flow.reset(false);
     flow.open(1);
-    flow.advertise(1);
     await flow.waitToSend(1, WINDOW_BYTES);
 });
 
@@ -205,24 +204,18 @@ test('legacy mode still bounds local receive queues without sending controls', (
     assert.equal(flow.receive(3, 0), true);
 });
 
-test('failed window controls are surfaced without recording a grant', () => {
-    let send = false;
+test('failed replenishment control is surfaced without recording a grant', () => {
     const controls = [];
     const flow = new Controller(msg => {
         controls.push(msg);
-        return send;
+        return false;
     });
     flow.reset(true);
     flow.open(1);
 
-    assert.equal(flow.advertise(1), false);
-    send = true;
-    assert.equal(flow.advertise(1), true);
-    assert.equal(controls.length, 2);
-
     assert.equal(flow.receive(1, UPDATE_BYTES), true);
-    send = false;
     assert.equal(flow.consume(1, UPDATE_BYTES), false);
+    assert.equal(controls.length, 1);
     assert.equal(flow.streams.get(1).lastUpdateBytes, 0);
     assert.equal(flow.streams.get(1).recvLimit, WINDOW_BYTES);
 });

--- a/bitbang-server/web_test/flow-control.test.js
+++ b/bitbang-server/web_test/flow-control.test.js
@@ -1,0 +1,228 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    Controller,
+    WINDOW_BYTES,
+    UPDATE_BYTES,
+    negotiateVersion,
+    asBytes,
+    createFrame,
+    parseFrame,
+    MAX_PAYLOAD_BYTES,
+} = require('../web/flow-control.js');
+
+test('version negotiation preserves legacy peers and selects v4 explicitly', () => {
+    assert.deepEqual(negotiateVersion(), { serverVersion: 2, negotiatedVersion: 2 });
+    assert.deepEqual(negotiateVersion(3), { serverVersion: 3, negotiatedVersion: 3 });
+    assert.deepEqual(negotiateVersion(4, 4), { serverVersion: 4, negotiatedVersion: 4 });
+    assert.deepEqual(negotiateVersion(99, 4), { serverVersion: 99, negotiatedVersion: 4 });
+    assert.deepEqual(negotiateVersion(4, 3), { serverVersion: 4, negotiatedVersion: 3 });
+    assert.throws(() => negotiateVersion(3, 4), /invalid SWSP version/);
+    assert.throws(() => negotiateVersion(4, 0), /invalid SWSP version/);
+    assert.throws(() => negotiateVersion(1), /unsupported SWSP server/);
+});
+
+test('ArrayBuffer views preserve their exact underlying bytes', () => {
+    const source = new Uint8Array([9, 8, 0x34, 0x12, 7]);
+    const words = new Uint16Array(source.buffer, 2, 1);
+    const dataView = new DataView(source.buffer, 2, 2);
+
+    assert.deepEqual(Array.from(asBytes(words)), [0x34, 0x12]);
+    assert.deepEqual(Array.from(asBytes(dataView)), [0x34, 0x12]);
+    assert.deepEqual(Array.from(asBytes(source.buffer)), [9, 8, 0x34, 0x12, 7]);
+});
+
+test('frame codec rejects oversized, truncated, and trailing payloads', () => {
+    const frame = createFrame(7, 2, new Uint8Array([1, 2, 3]));
+    const parsed = parseFrame(frame);
+    assert.equal(parsed.streamId, 7);
+    assert.equal(parsed.flags, 2);
+    assert.deepEqual(Array.from(new Uint8Array(parsed.payload)), [1, 2, 3]);
+
+    assert.throws(
+        () => createFrame(1, 0, new Uint8Array(MAX_PAYLOAD_BYTES + 1)),
+        /exceeds frame limit/);
+    assert.throws(() => parseFrame(frame.slice(0, -1)), /does not match/);
+    const trailing = new Uint8Array(frame.byteLength + 1);
+    trailing.set(new Uint8Array(frame));
+    assert.throws(() => parseFrame(trailing), /does not match/);
+});
+
+test('sender stops at the advertised window and resumes on update', async () => {
+    const controls = [];
+    const flow = new Controller(msg => {
+        controls.push(msg);
+        return true;
+    });
+    flow.reset(true);
+    flow.open(1);
+    flow.advertise(1);
+
+    assert.deepEqual(controls, [{
+        type: 'window_update', stream_id: 1, max_bytes: WINDOW_BYTES,
+    }]);
+
+    assert.equal(flow.updateWindow(1, WINDOW_BYTES), true);
+    await flow.waitToSend(1, WINDOW_BYTES);
+
+    let released = false;
+    const blocked = flow.waitToSend(1, 1).then(() => { released = true; });
+    await Promise.resolve();
+    assert.equal(released, false);
+
+    assert.equal(flow.updateWindow(1, WINDOW_BYTES + 1), true);
+    await blocked;
+    assert.equal(released, true);
+});
+
+test('receive limit is replenished only after the consumption threshold', () => {
+    const controls = [];
+    const flow = new Controller(msg => {
+        controls.push(msg);
+        return true;
+    });
+    flow.reset(true);
+    flow.open(3);
+    flow.advertise(3);
+
+    assert.equal(flow.receive(3, UPDATE_BYTES - 1), true);
+    flow.consume(3, UPDATE_BYTES - 1);
+    assert.equal(controls.length, 1);
+
+    assert.equal(flow.receive(3, 1), true);
+    flow.consume(3, 1);
+    assert.deepEqual(controls[1], {
+        type: 'window_update',
+        stream_id: 3,
+        max_bytes: WINDOW_BYTES + UPDATE_BYTES,
+    });
+});
+
+test('receive and frame limits reject only the offending stream', () => {
+    const flow = new Controller(() => {});
+    flow.reset(true);
+    flow.open(1);
+    flow.open(3);
+
+    assert.equal(flow.receive(1, WINDOW_BYTES), true);
+    assert.equal(flow.receive(1, 1), false);
+    assert.equal(flow.receive(3, 1), true);
+});
+
+test('empty frames are bounded and released by consumption', () => {
+    const flow = new Controller(() => {});
+    flow.reset(true);
+    flow.open(1);
+
+    for (let i = 0; i < 256; i++) assert.equal(flow.receive(1, 0), true);
+    assert.equal(flow.receive(1, 0), false);
+    assert.equal(flow.consume(1, 0, 256), true);
+    assert.equal(flow.receive(1, 0), true);
+});
+
+test('receive direction rejects every frame after FIN', () => {
+    const flow = new Controller(() => {});
+    flow.reset(true);
+    flow.open(1);
+
+    assert.equal(flow.receive(1, 0, true), true);
+    assert.equal(flow.receive(1, 1, false), false);
+    assert.equal(flow.finishReceive(1), false);
+});
+
+test('consumption cannot exceed outstanding bytes or frames', () => {
+    const flow = new Controller(() => {});
+    flow.reset(true);
+    flow.open(1);
+    assert.equal(flow.receive(1, 10), true);
+
+    assert.equal(flow.consume(1, -1), false);
+    assert.equal(flow.consume(1, Number.NaN), false);
+    assert.equal(flow.consume(1, 11), false);
+    assert.equal(flow.consume(1, 10, 2), false);
+    assert.equal(flow.consume(1, 10), true);
+    assert.equal(flow.consume(1, 0), false);
+});
+
+test('window updates require a positive maximum', () => {
+    const flow = new Controller(() => {});
+    flow.reset(true);
+    flow.open(1);
+
+    assert.equal(flow.updateWindow(1, 0), false);
+    assert.equal(flow.updateWindow(1, -1), false);
+    assert.equal(flow.updateWindow(1, Number.NaN), false);
+    assert.equal(flow.updateWindow(1, 10), true);
+    assert.equal(flow.updateWindow(1, 5), true);
+    assert.equal(flow.updateWindow(1, 10), true);
+});
+
+test('zero-byte sends still require a live stream', async () => {
+    const flow = new Controller(() => {});
+    flow.reset(true);
+    flow.open(1);
+    flow.resetStream(1, new Error('reset'));
+    await assert.rejects(flow.waitToSend(1, 0), /before SYN/);
+});
+
+test('reset rejects blocked senders without affecting another stream', async () => {
+    const flow = new Controller(() => {});
+    flow.reset(true);
+    flow.open(1);
+    flow.open(3);
+
+    const blocked = flow.waitToSend(1, 1);
+    flow.resetStream(1, new Error('stalled'));
+    await assert.rejects(blocked, /stalled/);
+
+    flow.updateWindow(3, 1);
+    await flow.waitToSend(3, 1);
+});
+
+test('legacy mode never waits for credit', async () => {
+    const flow = new Controller(() => assert.fail('legacy mode sent control'));
+    flow.reset(false);
+    flow.open(1);
+    flow.advertise(1);
+    await flow.waitToSend(1, WINDOW_BYTES);
+});
+
+test('legacy mode still bounds local receive queues without sending controls', () => {
+    const flow = new Controller(() => assert.fail('legacy mode sent control'));
+    flow.reset(false);
+    flow.open(1);
+
+    assert.equal(flow.receive(1, WINDOW_BYTES), true);
+    assert.equal(flow.receive(1, 1), false);
+    assert.equal(flow.consume(1, WINDOW_BYTES), true);
+    assert.equal(flow.receive(1, WINDOW_BYTES), true);
+
+    flow.open(3);
+    for (let i = 0; i < 256; i++) assert.equal(flow.receive(3, 0), true);
+    assert.equal(flow.receive(3, 0), false);
+    assert.equal(flow.consume(3, 0, 256), true);
+    assert.equal(flow.receive(3, 0), true);
+});
+
+test('failed window controls are surfaced without recording a grant', () => {
+    let send = false;
+    const controls = [];
+    const flow = new Controller(msg => {
+        controls.push(msg);
+        return send;
+    });
+    flow.reset(true);
+    flow.open(1);
+
+    assert.equal(flow.advertise(1), false);
+    send = true;
+    assert.equal(flow.advertise(1), true);
+    assert.equal(controls.length, 2);
+
+    assert.equal(flow.receive(1, UPDATE_BYTES), true);
+    send = false;
+    assert.equal(flow.consume(1, UPDATE_BYTES), false);
+    assert.equal(flow.streams.get(1).lastUpdateBytes, 0);
+    assert.equal(flow.streams.get(1).recvLimit, WINDOW_BYTES);
+});

--- a/bitbang-server/web_test/sw-upload.test.js
+++ b/bitbang-server/web_test/sw-upload.test.js
@@ -1,0 +1,45 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    AckGate,
+    MAX_SLICE_BYTES,
+    copySlice,
+} = require('../web/sw-upload.js');
+
+test('request body chunks are copied into bounded transferable slices', () => {
+    const source = new Uint8Array(MAX_SLICE_BYTES + 3);
+    source[0] = 1;
+    source[MAX_SLICE_BYTES] = 2;
+
+    const first = copySlice(source, 0);
+    const second = copySlice(source, first.byteLength);
+
+    assert.equal(first.byteLength, MAX_SLICE_BYTES);
+    assert.equal(second.byteLength, 3);
+    assert.notEqual(first.buffer, source.buffer);
+    assert.notEqual(second.buffer, source.buffer);
+    assert.equal(first[0], 1);
+    assert.equal(second[0], 2);
+});
+
+test('terminal errors reject both current and future acknowledgements', async () => {
+    const gate = new AckGate(1000);
+    const current = gate.wait(1);
+
+    gate.fail(new Error('peer reset'));
+
+    await assert.rejects(current, /peer reset/);
+    await assert.rejects(gate.wait(2), /peer reset/);
+});
+
+test('an error latched between chunks rejects the next acknowledgement immediately', async () => {
+    const gate = new AckGate(1000);
+    const first = gate.wait(1);
+    assert.equal(gate.acknowledge(1), true);
+    await first;
+
+    gate.fail(new Error('stream closed'));
+
+    await assert.rejects(gate.wait(2), /stream closed/);
+});


### PR DESCRIPTION
## Summary

- add SWSP v4 per-stream send credit and bounded receive accounting to the browser transport
- make HTTP upload/download backpressure follow actual service-worker consumption
- stream WebSocket messages in bounded transport fragments while preserving message boundaries
- isolate malformed, slow, or reset streams without stalling other browser traffic
- preserve the v2/v3 wire path while retaining local queue bounds
- add a CI workflow: `node --check` on the browser scripts, `node --test` on `web_test/`

## Motivation

This is the browser-side companion for [richlegrand/bitbang-cli#14](https://github.com/richlegrand/bitbang-cli/issues/14). A single slow consumer could previously let one stream monopolize the shared data-channel receive path or accumulate unbounded listener-side work.

SWSP v4 adds cumulative per-stream window updates and stream-local resets. These controls are enabled only after explicit negotiation, so existing listeners continue to use the legacy wire behavior.

## Testing

- `go test -count=1 ./...`
- `go vet ./...`
- `go build ./...`
- `node --test web_test/flow-control.test.js web_test/sw-upload.test.js`
- `node --check` for the updated browser and service-worker scripts
- CLI Playwright suite against the deployed `test.bitba.ng` (v3 assets): 10 passed. This exercises only the downgrade path from a v4 connector — none of this branch's browser code runs.
- CLI Playwright suite against this branch served locally: 10 passed, with the browser reporting `negotiatedVersion: 4` (checked via `window.__bitbangConnection`). Recipe:
  1. `go run ./cmd/signaling` from this branch's `bitbang-server/` — serves `./web` on :8082
  2. a TLS terminator on :8443 forwarding to :8082, using a certificate the browser trusts (mkcert, or a throwaway CA imported into `~/.pki/nssdb` with `certutil`) — the CLI always dials `wss://`
  3. from `bitbang-cli`: `BITBANG_TEST_SERVER=localhost:8443 BITBANG_BIN=<bitbang built from bitbang-cli main, which includes #15> python -m pytest tests/e2e/`

## Companion PR

- [richlegrand/bitbang-cli#15](https://github.com/richlegrand/bitbang-cli/pull/15) adds the matching listener and connector implementation and closes issue #14.